### PR TITLE
Adding in the ability to retrieve the RunID from a Jenkins Build Variable - HP_RUN_ID

### DIFF
--- a/src/main/java/com/hp/application/automation/tools/run/PcBuilder.java
+++ b/src/main/java/com/hp/application/automation/tools/run/PcBuilder.java
@@ -56,7 +56,7 @@ public class PcBuilder extends Builder {
     public static final String runReportStructure = "%s/%s/performanceTestsReports/pcRun%s";
     public static final String pcReportArchiveName = "Reports.zip";
     public static final String pcReportFileName = "Report.html";
-	private static final String RUNID_BUILD_VARIABLE = "HP_RUN_ID";
+  	private static final String RUNID_BUILD_VARIABLE = "HP_RUN_ID";
     
     private final PcModel pcModel;
     private final boolean statusBySLA;
@@ -103,7 +103,6 @@ public class PcBuilder extends Builder {
     public DescriptorImpl getDescriptor() {
         
         return (DescriptorImpl) super.getDescriptor();
-
     }
     
     @Override
@@ -190,14 +189,13 @@ public class PcBuilder extends Builder {
         PcRunResponse response = null;
         String errorMessage = "";
         String eventLogString = "";
-
         try {
             runId = pcClient.startRun();
-              
+            
             // This allows a user to access the runId from within Jenkins using a build variable.
             build.addAction(new ParametersAction(new StringParameterValue(RUNID_BUILD_VARIABLE, "" + runId))); 
             logger.print("Set " + RUNID_BUILD_VARIABLE + " Env Variable to " + runId + "\n");
-          
+            
             response = pcClient.waitForRunCompletion(runId);
             if (response != null && RunState.get(response.getRunState()) == FINISHED) {
                 pcReportFile = pcClient.publishRunReport(runId, getReportDirectory(build));


### PR DESCRIPTION
I've required the RunID for later steps in my build process, so I've changed this class to output the RunId to a variable.

This means in later steps, I can use ${HP_RUN_ID} to get the Run ID.
