### PR TITLE
add jenkins variables expansion in test set name

### DIFF
--- a/src/main/java/com/hp/application/automation/tools/model/RunFromAlmModel.java
+++ b/src/main/java/com/hp/application/automation/tools/model/RunFromAlmModel.java
@@ -141,7 +141,8 @@ public class RunFromAlmModel {
 			int i = 1;
 
 			for (String testSet : testSetsArr) {
-				props.put("TestSet" + i, testSet);
+				props.put("TestSet" + i, 
+					Util.replaceMacro(envVars.expand(testSet), varResolver));
 				i++;
 			}
 		} else {


### PR DESCRIPTION
Enabling jenkins variable expansion in test set name allows to dynamically define which test set you want to execute based on some jenkins variable