### PR TITLE
Fixed two error handling when upload external test result.

### DIFF
--- a/src/main/java/com/hp/application/automation/tools/results/TestResultToALMUploader.java
+++ b/src/main/java/com/hp/application/automation/tools/results/TestResultToALMUploader.java
@@ -155,17 +155,21 @@ public class TestResultToALMUploader extends Recorder implements Serializable, M
     			AlmRestTool u = new AlmRestTool(loginInfo, logger);
     			logger.log("INFO: Start to upload "+fullpath);
     			IExternalEntityUploadService service = new DefaultExternalEntityUploadServiceImpl(u, logger );
-    			service.UploadExternalTestSet(loginInfo, 
-    											fullpath, 
-    											uploadTestResultToAlmModel.getAlmTestSetFolder(), 
-    											uploadTestResultToAlmModel.getAlmTestFolder(), 
-    											uploadTestResultToAlmModel.getTestingFramework(), 
-    											uploadTestResultToAlmModel.getTestingTool(), 
-    											String.valueOf(build.getNumber()),
-    											build.getParent().getDisplayName(),
-    											runUrl
-    											);
-    			logger.log("INFO: Uploaded "+fullpath + ".");
+    			try {
+	    			service.UploadExternalTestSet(loginInfo, 
+	    											fullpath, 
+	    											uploadTestResultToAlmModel.getAlmTestSetFolder(), 
+	    											uploadTestResultToAlmModel.getAlmTestFolder(), 
+	    											uploadTestResultToAlmModel.getTestingFramework(), 
+	    											uploadTestResultToAlmModel.getTestingTool(), 
+	    											String.valueOf(build.getNumber()),
+	    											build.getParent().getDisplayName(),
+	    											runUrl
+	    											);
+	    			logger.log("INFO: Uploaded "+fullpath + ".");
+    			} catch (Exception e) {
+    				logger.log("WARN: there's exception while uploading "+fullpath + ".");
+    			}
 
         	}
         }

--- a/src/main/java/com/hp/application/automation/tools/results/parser/ReportParseException.java
+++ b/src/main/java/com/hp/application/automation/tools/results/parser/ReportParseException.java
@@ -6,5 +6,24 @@ public class ReportParseException extends Exception {
 	 * 
 	 */
 	private static final long serialVersionUID = 1L;
+	
+    public ReportParseException(){
+    	
+    }
+    
+    public ReportParseException(Throwable cause) {
+        
+        super(cause);
+    }
+    
+    public ReportParseException(String message) {
+        
+        super(message);
+    }
+    
+    public ReportParseException(String message, Throwable cause) {
+        
+        super(message, cause);
+    }	
 
 }

--- a/src/main/java/com/hp/application/automation/tools/results/parser/ReportParserManager.java
+++ b/src/main/java/com/hp/application/automation/tools/results/parser/ReportParserManager.java
@@ -40,7 +40,9 @@ public class ReportParserManager {
 				testsets = reportParser.parseTestSets(in, testingFramework, testingTool);
 				break;
 			} catch (Exception e) {
+				
 				e.printStackTrace();
+				
 			}
 		}
 

--- a/src/main/java/com/hp/application/automation/tools/results/service/AlmRestException.java
+++ b/src/main/java/com/hp/application/automation/tools/results/service/AlmRestException.java
@@ -1,0 +1,21 @@
+package com.hp.application.automation.tools.results.service;
+
+public class AlmRestException extends Exception{
+	
+    private static final long serialVersionUID = -5386355008323770238L;
+    
+    public AlmRestException(Throwable cause) {
+        
+        super(cause);
+    }
+    
+    public AlmRestException(String message) {
+        
+        super(message);
+    }
+    
+    public AlmRestException(String message, Throwable cause) {
+        
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/hp/application/automation/tools/results/service/AlmRestTool.java
+++ b/src/main/java/com/hp/application/automation/tools/results/service/AlmRestTool.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.hp.application.automation.tools.common.Pair;
+import com.hp.application.automation.tools.common.SSEException;
 import com.hp.application.automation.tools.rest.RestClient;
 import com.hp.application.automation.tools.results.service.almentities.AlmEntity;
 import com.hp.application.automation.tools.results.service.rest.CreateAlmEntityRequest;
@@ -57,7 +58,7 @@ public class AlmRestTool {
     
     
 	
-	public boolean login() {
+	public boolean login() throws Exception {
 
 		boolean ret = true;
         try {
@@ -74,6 +75,7 @@ public class AlmRestTool {
                     "Failed login to ALM Server URL: %s. Exception: %s",
                     almLoginInfo.getServerUrl(),
                     cause.getMessage()));
+            throw new AlmRestException (cause);
         }        
         return ret;
 	}

--- a/src/main/java/com/hp/application/automation/tools/results/service/DefaultExternalEntityUploadServiceImpl.java
+++ b/src/main/java/com/hp/application/automation/tools/results/service/DefaultExternalEntityUploadServiceImpl.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 
-import com.hp.application.automation.tools.results.parser.ReportParseException;
 import com.hp.application.automation.tools.results.parser.ReportParserManager;
 import com.hp.application.automation.tools.results.service.almentities.AlmCommonProperties;
 import com.hp.application.automation.tools.results.service.almentities.AlmEntity;
@@ -338,7 +337,7 @@ public class DefaultExternalEntityUploadServiceImpl implements
 							String testingTool, 
 							String subversion,
 							String jobName, 
-							String buildUrl) throws Exception{
+							String buildUrl) throws ExternalEntityUploadException{
 		
 		logger.log("INFO: Start to parse file: " +reportFilePath);
 		
@@ -346,32 +345,36 @@ public class DefaultExternalEntityUploadServiceImpl implements
 		
 		if(testsets == null) {
 			logger.log("Failed to parse file: " + reportFilePath);
-			throw new ReportParseException("Failed to parse file: " + reportFilePath);
+			throw new ExternalEntityUploadException("Failed to parse file: " + reportFilePath);
 		} else  {
 			logger.log("INFO: parse resut file succeed.");
 		}
 		
 		if(testsets != null && testsets.size() >0 ) {
 			logger.log("INFO: Start to login to ALM Server.");
-			if( restTool.login() ) {
-			
-				logger.log("INFO: Checking test folder...");
-				AlmTestFolder testFolder = createTestFolderPath(2, testFolderPath);
-				logger.log("INFO: Checking testset folder...");
-				AlmTestSetFolder testsetFolder = createTestSetFolderPath (0, testsetFolderPath);
-				if(testFolder != null && testsetFolder != null){
-					logger.log("INFO: Uploading ALM Entities...");
-					importExternalTestSet(
-							testsets, 
-							loginInfo.getUserName(), 
-							Integer.valueOf(testsetFolder.getId()), 
-							Integer.valueOf(testFolder.getId()), 
-							testingTool, 
-							subversion, 
-							jobName, 
-							buildUrl);
+			try {
+				if( restTool.login() ) {
+				
+					logger.log("INFO: Checking test folder...");
+					AlmTestFolder testFolder = createTestFolderPath(2, testFolderPath);
+					logger.log("INFO: Checking testset folder...");
+					AlmTestSetFolder testsetFolder = createTestSetFolderPath (0, testsetFolderPath);
+					if(testFolder != null && testsetFolder != null){
+						logger.log("INFO: Uploading ALM Entities...");
+						importExternalTestSet(
+								testsets, 
+								loginInfo.getUserName(), 
+								Integer.valueOf(testsetFolder.getId()), 
+								Integer.valueOf(testFolder.getId()), 
+								testingTool, 
+								subversion, 
+								jobName, 
+								buildUrl);
+					}
 				}
-			} 
+			} catch (Exception e) {
+				throw new ExternalEntityUploadException(e);
+			}
 		}
 	}
 	

--- a/src/main/java/com/hp/application/automation/tools/results/service/DefaultExternalEntityUploadServiceImpl.java
+++ b/src/main/java/com/hp/application/automation/tools/results/service/DefaultExternalEntityUploadServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 
+import com.hp.application.automation.tools.results.parser.ReportParseException;
 import com.hp.application.automation.tools.results.parser.ReportParserManager;
 import com.hp.application.automation.tools.results.service.almentities.AlmCommonProperties;
 import com.hp.application.automation.tools.results.service.almentities.AlmEntity;
@@ -337,7 +338,7 @@ public class DefaultExternalEntityUploadServiceImpl implements
 							String testingTool, 
 							String subversion,
 							String jobName, 
-							String buildUrl){
+							String buildUrl) throws Exception{
 		
 		logger.log("INFO: Start to parse file: " +reportFilePath);
 		
@@ -345,31 +346,32 @@ public class DefaultExternalEntityUploadServiceImpl implements
 		
 		if(testsets == null) {
 			logger.log("Failed to parse file: " + reportFilePath);
+			throw new ReportParseException("Failed to parse file: " + reportFilePath);
 		} else  {
 			logger.log("INFO: parse resut file succeed.");
 		}
 		
 		if(testsets != null && testsets.size() >0 ) {
 			logger.log("INFO: Start to login to ALM Server.");
-			restTool.login();
+			if( restTool.login() ) {
 			
-			logger.log("INFO: Checking test folder...");
-			AlmTestFolder testFolder = createTestFolderPath(2, testFolderPath);
-			logger.log("INFO: Checking testset folder...");
-			AlmTestSetFolder testsetFolder = createTestSetFolderPath (0, testsetFolderPath);
-			if(testFolder != null && testsetFolder != null){
-				logger.log("INFO: Uploading ALM Entities...");
-				importExternalTestSet(
-						testsets, 
-						loginInfo.getUserName(), 
-						Integer.valueOf(testsetFolder.getId()), 
-						Integer.valueOf(testFolder.getId()), 
-						testingTool, 
-						subversion, 
-						jobName, 
-						buildUrl);
-			}			
-
+				logger.log("INFO: Checking test folder...");
+				AlmTestFolder testFolder = createTestFolderPath(2, testFolderPath);
+				logger.log("INFO: Checking testset folder...");
+				AlmTestSetFolder testsetFolder = createTestSetFolderPath (0, testsetFolderPath);
+				if(testFolder != null && testsetFolder != null){
+					logger.log("INFO: Uploading ALM Entities...");
+					importExternalTestSet(
+							testsets, 
+							loginInfo.getUserName(), 
+							Integer.valueOf(testsetFolder.getId()), 
+							Integer.valueOf(testFolder.getId()), 
+							testingTool, 
+							subversion, 
+							jobName, 
+							buildUrl);
+				}
+			} 
 		}
 	}
 	

--- a/src/main/java/com/hp/application/automation/tools/results/service/ExternalEntityUploadException.java
+++ b/src/main/java/com/hp/application/automation/tools/results/service/ExternalEntityUploadException.java
@@ -1,0 +1,21 @@
+package com.hp.application.automation.tools.results.service;
+
+public class ExternalEntityUploadException extends Exception{
+	
+    private static final long serialVersionUID = -5386355008323770238L;
+    
+    public ExternalEntityUploadException(Throwable cause) {
+        
+        super(cause);
+    }
+    
+    public ExternalEntityUploadException(String message) {
+        
+        super(message);
+    }
+    
+    public ExternalEntityUploadException(String message, Throwable cause) {
+        
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/hp/application/automation/tools/results/service/IExternalEntityUploadService.java
+++ b/src/main/java/com/hp/application/automation/tools/results/service/IExternalEntityUploadService.java
@@ -2,6 +2,6 @@ package com.hp.application.automation.tools.results.service;
 
 public interface IExternalEntityUploadService {
 
-	public void UploadExternalTestSet(AlmRestInfo loginInfo, String reportFilePath, String testsetFolderPath, String testFolderPath, String testingFramework, String testingTool, String subversion, String jobName, String buildUrl) throws Exception;	
+	public void UploadExternalTestSet(AlmRestInfo loginInfo, String reportFilePath, String testsetFolderPath, String testFolderPath, String testingFramework, String testingTool, String subversion, String jobName, String buildUrl) throws ExternalEntityUploadException;	
 
 }

--- a/src/main/java/com/hp/application/automation/tools/results/service/IExternalEntityUploadService.java
+++ b/src/main/java/com/hp/application/automation/tools/results/service/IExternalEntityUploadService.java
@@ -2,6 +2,6 @@ package com.hp.application.automation.tools.results.service;
 
 public interface IExternalEntityUploadService {
 
-	public void UploadExternalTestSet(AlmRestInfo loginInfo, String reportFilePath, String testsetFolderPath, String testFolderPath, String testingFramework, String testingTool, String subversion, String jobName, String buildUrl);	
+	public void UploadExternalTestSet(AlmRestInfo loginInfo, String reportFilePath, String testsetFolderPath, String testFolderPath, String testingFramework, String testingTool, String subversion, String jobName, String buildUrl) throws Exception;	
 
 }

--- a/src/test/java/com/hp/application/automation/tools/results/service/TestDefaultExternalEntityUploadServiceImpl.java
+++ b/src/test/java/com/hp/application/automation/tools/results/service/TestDefaultExternalEntityUploadServiceImpl.java
@@ -4,7 +4,7 @@ package com.hp.application.automation.tools.results.service;
 public class TestDefaultExternalEntityUploadServiceImpl {
 
 	
-	private static void testJunit(int i){
+	private static void testJunit(int i) throws Exception{
 		AlmRestInfo loginInfo = new AlmRestInfo(
 				"http://localhost:8085/qcbin",
 				"DEFAULT",
@@ -29,7 +29,7 @@ public class TestDefaultExternalEntityUploadServiceImpl {
 		
 	}
 	
-	private static void testtestNG(int i){
+	private static void testtestNG(int i) throws Exception{
 		AlmRestInfo loginInfo = new AlmRestInfo(
 				"http://localhost:8085/qcbin",
 				"DEFAULT",
@@ -54,7 +54,7 @@ public class TestDefaultExternalEntityUploadServiceImpl {
 		System.out.println("total time:" + (end -start));		
 	}
 	
-	private static void testnunit(int i){
+	private static void testnunit(int i) throws Exception{
 		AlmRestInfo loginInfo = new AlmRestInfo(
 				"http://localhost:8085/qcbin",
 				"DEFAULT",
@@ -80,7 +80,7 @@ public class TestDefaultExternalEntityUploadServiceImpl {
 		System.out.println("total time:" + (end -start));	
 	}
 	
-	public static void main(String[] argc) {
+	public static void main(String[] argc) throws Exception{
 		testJunit(109);
 		//testtestNG(107);
 		//testnunit(108);


### PR DESCRIPTION
[Jenkins CI plugin] [External test]: Message "Uploaded
<filepath>\<filename>" appears in Jenkins console output after failing
to parse the file
[External Tests] Jenkins Plugin: Export results should be stopped after
failed login to ALM