### PR TITLE
Fixed a issue which happens when test sets contatins a empty line

### DIFF
--- a/src/main/java/com/hp/application/automation/tools/model/RunFromAlmModel.java
+++ b/src/main/java/com/hp/application/automation/tools/model/RunFromAlmModel.java
@@ -141,9 +141,11 @@ public class RunFromAlmModel {
 			int i = 1;
 
 			for (String testSet : testSetsArr) {
-				props.put("TestSet" + i,
-					Util.replaceMacro(envVars.expand(testSet), varResolver));
-				i++;
+				if (!StringUtils.isBlank(testSet)) {
+					props.put("TestSet" + i,
+						Util.replaceMacro(envVars.expand(testSet), varResolver));
+					i++;
+				}
 			}
 		} else {
 			props.put("almTestSets", "");

--- a/src/main/java/com/hp/application/automation/tools/run/RunFromAlmBuilder.java
+++ b/src/main/java/com/hp/application/automation/tools/run/RunFromAlmBuilder.java
@@ -323,6 +323,13 @@ public class RunFromAlmBuilder extends Builder {
                 return FormValidation.error("Testsets are missing");
             }
             
+            String[] testSetsArr = value.replaceAll("\r", "").split("\n");
+
+			for (int i=0; i < testSetsArr.length; i++) {
+				if (StringUtils.isBlank(testSetsArr[i])) {
+					return FormValidation.error("Testsets should not contains empty lines");
+				}
+			}
             return FormValidation.ok();
         }
         


### PR DESCRIPTION
Issue:
If the test sets contains a empty line, it would be consider as a test set fold name "".
So there would be a folder not found error occur.
Changes:
Remove the empty test sets while reading from the config.
Add a validation of check the test sets input.