### PR TITLE
Fix a issue that inputting a string which is not numeric would cause …

### DIFF
--- a/src/main/java/com/hp/application/automation/tools/run/SseBuilder.java
+++ b/src/main/java/com/hp/application/automation/tools/run/SseBuilder.java
@@ -297,15 +297,21 @@ public class SseBuilder extends Builder {
         }
         
         public FormValidation doCheckTimeslotDuration(@QueryParameter String value) {
-            
-            FormValidation ret = FormValidation.ok();
             if (StringUtils.isBlank(value)) {
-                ret = FormValidation.error("Timeslot duration must be set");
-            } else if (Integer.valueOf(value) < 30) {
-                ret = FormValidation.error("Timeslot duration must be higher than 30");
+            	return FormValidation.error("Timeslot duration must be set");
             }
             
-            return ret;
+            String val1 = value.trim();
+            
+            if (!StringUtils.isNumeric(val1)) {
+            	return FormValidation.error("Timeslot duration must be a number");
+            }
+            
+            if (Integer.valueOf(val1) < 30) {
+            	return FormValidation.error("Timeslot duration must be higher than 30");
+            }
+            
+            return FormValidation.ok();
         }
         
         public FormValidation doCheckAlmDomain(@QueryParameter String value) {


### PR DESCRIPTION
…a NumberFormat exception, in the field 'Timeslot Duration' of the build step 'Execute hp tests using hp alm lab management'.