### PR TITLE
Enable https for ALM server settings

### DIFF
--- a/src/main/java/com/hp/application/automation/tools/settings/AlmServerSettingsBuilder.java
+++ b/src/main/java/com/hp/application/automation/tools/settings/AlmServerSettingsBuilder.java
@@ -8,13 +8,13 @@ package com.hp.application.automation.tools.settings;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
-import java.net.URL;
 
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import com.hp.application.automation.tools.model.AlmServerSettingsModel;
+import com.hp.application.automation.tools.rest.RestClient;
 import com.hp.application.automation.tools.sse.sdk.RestAuthenticator;
 
 import hudson.CopyOnWrite;
@@ -149,7 +149,7 @@ public class AlmServerSettingsBuilder extends Builder {
             // Open the connection and perform a HEAD request
             HttpURLConnection connection;
             try {
-                connection = (HttpURLConnection) new URL(url).openConnection();
+            	connection = (HttpURLConnection) RestClient.openConnection(null, url);
                 connection.setRequestMethod("GET");
                 
                 // Check whether the response is from ALM Server


### PR DESCRIPTION
Modified the RestClient to enable SSL. So now we can configure a https url for ALM server and start tests of SSE build step via SSL.
Linked to [Jira case number 22435](https://issues.jenkins-ci.org/browse/JENKINS-22435)