### PR TITLE
Defect fixes: Null pointer exception during job configuration (FreeStyleBuild), Controller trying to close after being closed

### DIFF
--- a/HpToolsLauncher/TestRunners/PerformanceTestRunner.cs
+++ b/HpToolsLauncher/TestRunners/PerformanceTestRunner.cs
@@ -525,16 +525,21 @@ namespace HpToolsLauncher.TestRunners
             {
                 try
                 {
-                    int rc = _engine.CloseController();
-                    if (rc != 0)
+                    var process = Process.GetProcessesByName("Wlrun");
+                    if (process.Length > 0)
                     {
-                        ConsoleWriter.WriteErrLine("\t\tFailed to close Controller with CloseController API function, rc: " + rc);
+                        int rc = _engine.CloseController();
+                        if (rc != 0)
+                        {
+                            ConsoleWriter.WriteErrLine(
+                                "\t\tFailed to close Controller with CloseController API function, rc: " + rc);
+                        }
                     }
 
                     //give the controller 15 secs to shutdown. otherwise, print an error.
                     Thread.Sleep(15000);
 
-                    var process = Process.GetProcessesByName("Wlrun");
+                    process = Process.GetProcessesByName("Wlrun");
                     if (process.Length > 0)
                     {
                         ConsoleWriter.WriteErrLine("\t\tThe Controller is still running...");

--- a/src/main/java/com/hp/application/automation/tools/results/RunResultRecorder.java
+++ b/src/main/java/com/hp/application/automation/tools/results/RunResultRecorder.java
@@ -66,7 +66,6 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
 	private static final String TRANSACTION_SUMMARY_FOLDER = "TransactionSummary";
 	private static final String TRANSACTION_REPORT_NAME = "Report3";
 	private final ResultsPublisherModel _resultsPublisherModel;
-	private TaskListener _logger;
 
 	/**
 	 * Instantiates a new Run result recorder.
@@ -105,7 +104,7 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
 								@Nonnull TaskListener listener, @Nonnull Map<String, String> builderResultNames)
 			throws IOException, InterruptedException {
 		final List<String> mergedResultNames = new ArrayList<String>();
-		this._logger = listener;
+		TaskListener _logger = listener;
 
 		final List<String> fileSystemResultNames = new ArrayList<String>();
 		fileSystemResultNames.add(builderResultNames.get(RunFromFileBuilder.class.getName()));
@@ -404,7 +403,7 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
 					// serialize report metadata
 					File reportMetaDataXmlFile = new File(artifactsDir.getParent(), REPORTMETADATE_XML);
 					String reportMetaDataXml = reportMetaDataXmlFile.getAbsolutePath();
-					writeReportMetaData2XML(ReportInfoToCollect, reportMetaDataXml);
+					writeReportMetaData2XML(ReportInfoToCollect, reportMetaDataXml, listener);
 
 					// Add UFT report action
 					try {
@@ -434,7 +433,7 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
 	}
 
 
-	private void writeReportMetaData2XML(List<ReportMetaData> htmlReportsInfo, String xmlFile) {
+	private void writeReportMetaData2XML(List<ReportMetaData> htmlReportsInfo, String xmlFile, TaskListener _logger) {
 
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 		DocumentBuilder builder = null;
@@ -824,7 +823,7 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
 
 	@Override
 	public void perform(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
-		this._logger = listener;
+		TaskListener _logger = listener;
 		final List<String> mergedResultNames = new ArrayList<String>();
 
 		Project<?, ?> project = RuntimeUtils.cast(build.getParent());


### PR DESCRIPTION
1. LR controller will try to get closed after already  being closed and lead to exception - LR API issue fix.
2. Serialization issue that led to NPE once a new job is created. [Link to issue]( https://issues.jenkins-ci.org/browse/JENKINS-39020)