### PR TITLE
Jenkins plugin size bloat fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,13 +256,6 @@
 			<artifactId>matrix-project</artifactId>
 			<version>1.6</version>
 		</dependency>
-
-		<dependency>
-			<groupId>org.jenkins-ci.main</groupId>
-			<artifactId>jenkins-test-harness</artifactId>
-			<version>1.642.3</version>
-		</dependency>
-
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-step-api</artifactId>
@@ -290,11 +283,6 @@
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>structs</artifactId>
 			<version>1.4</version>
-		</dependency>
-		<dependency>
-			<groupId>org.jenkins-ci.main</groupId>
-			<artifactId>cli</artifactId>
-			<version>2.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
Removed unneeded dependencies that led to plugin size bloat - Jenkins CLI and Jenkins test harness.