### PR TITLE
fix for JENKINS-40758: Support run native browser mobile tests from Jenkins

### DIFF
--- a/src/main/webapp/configure.js
+++ b/src/main/webapp/configure.js
@@ -25,7 +25,7 @@ function load(a,path){
                 buttonStatus = false;
                 return;
             }
-            var openedWindow = window.open(baseUrl+path+jobResponse+'&displayUFTMode=true&appType=native','test parameters','height=820','width=1130');
+            var openedWindow = window.open(baseUrl+path+jobResponse+'&displayUFTMode=true','test parameters','height=820','width=1130');
             var messageCallBack = function (event) {
                 if (event && event.data && event.data=="mcCloseWizard") {
                     a.populateAppAndDevice(baseUrl,mcUserName,mcPassword,proxyAddress, proxyUserName, proxyPassword,jobResponse, function (app) {


### PR DESCRIPTION
JENKINS-40758: Support run native browser mobile tests from Jenkins
related field in MC url is removed, thus users would be able to select browsers for testing.
https://issues.jenkins-ci.org/browse/JENKINS-40758