### PR TITLE
fix for JENKINS-39441：HP plugin doesnt fail pipeline stage in case if ALM server was not configured

### DIFF
--- a/src/main/java/com/hp/application/automation/tools/run/RunFromAlmBuilder.java
+++ b/src/main/java/com/hp/application/automation/tools/run/RunFromAlmBuilder.java
@@ -136,6 +136,7 @@ public class RunFromAlmBuilder extends Builder implements SimpleBuildStep {
         
         if (almServerSettingsModel == null) {
             listener.fatalError("An ALM server is not defined. Go to Manage Jenkins->Configure System and define your ALM server under Application Lifecycle Management");
+            build.setResult(Result.FAILURE);
             return;
         }
         

--- a/src/main/java/com/hp/application/automation/tools/run/RunFromAlmBuilder.java
+++ b/src/main/java/com/hp/application/automation/tools/run/RunFromAlmBuilder.java
@@ -136,7 +136,10 @@ public class RunFromAlmBuilder extends Builder implements SimpleBuildStep {
         
         if (almServerSettingsModel == null) {
             listener.fatalError("An ALM server is not defined. Go to Manage Jenkins->Configure System and define your ALM server under Application Lifecycle Management");
-            build.setResult(Result.FAILURE);
+            
+	    // set pipeline stage as failure in case if ALM server was not configured
+	    build.setResult(Result.FAILURE);
+		
             return;
         }
         


### PR DESCRIPTION
JENKINS-39441：HP plugin doesnt fail pipeline stage in case if ALM server was not configured(absent in Jenkins Configuration)
HP plugin now sets build status to failure before returning.
JIRA Link: https://issues.jenkins-ci.org/projects/JENKINS/issues/JENKINS-39441