### PR TITLE
Defect#5550: open job wizard without login again and keep the job info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 
 	<artifactId>hp-application-automation-tools-plugin</artifactId>
-	<version>5.0</version>
+	<version>5.1-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 	<name>HP Application Automation Tools</name>
 	<description>Allowing to run HP testing tools tests: Unified Functional Testing, QuickTest Professional, Service Test, Mobile Center and Performance Center

--- a/src/main/java/com/hp/application/automation/tools/run/RunFromFileBuilder.java
+++ b/src/main/java/com/hp/application/automation/tools/run/RunFromFileBuilder.java
@@ -542,7 +542,10 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
 		 * @return the job id
 		 */
 		@JavaScriptMethod
-		public String getJobId(String mcUrl, String mcUserName, String mcPassword, String proxyAddress, String proxyUserName, String proxyPassword) {
+		public String getJobId(String mcUrl, String mcUserName, String mcPassword, String proxyAddress, String proxyUserName, String proxyPassword, String previousJobId) {
+			if(null != previousJobId && !previousJobId.isEmpty()){
+				return previousJobId;
+			}
 			return instance.createTempJob(mcUrl, mcUserName, mcPassword, proxyAddress, proxyUserName, proxyPassword);
 		}
 

--- a/src/main/resources/com/hp/application/automation/tools/run/RunFromFileBuilder/config.jelly
+++ b/src/main/resources/com/hp/application/automation/tools/run/RunFromFileBuilder/config.jelly
@@ -122,7 +122,7 @@
                         <f:textbox name="runfromfs.fsDevicesMetrics" readonly = "true" value="${instance.runFromFileModel.fsDevicesMetrics}"/>
                 </f:entry>
                 <f:entry>
-                        <input id="wizard" type="button" value="wizard" onClick="load(a,'/integration/#/login?jobId=')"/>
+                        <input id="wizard" type="button" value="wizard" onClick="load(a,'/integration/#/wizard?jobId=')"/>
                 </f:entry>
                 <f:entry>
                         <div id="errorMessage" style="color:red;display:none">MC login information or proxy is incorrect.</div>

--- a/src/main/webapp/configure.js
+++ b/src/main/webapp/configure.js
@@ -16,9 +16,10 @@ function load(a,path){
         buttonStatus = false;
         return;
     }
+    var previousJobId = document.getElementsByName("runfromfs.fsJobId")[0].value;
     a.getMcServerUrl(mcUrl, function(r){
         baseUrl = r.responseObject();
-        a.getJobId(baseUrl,mcUserName, mcPassword, proxyAddress, proxyUserName, proxyPassword, function (response) {
+        a.getJobId(baseUrl,mcUserName, mcPassword, proxyAddress, proxyUserName, proxyPassword, previousJobId, function (response) {
             var jobResponse = response.responseObject();
             if(jobResponse == null){
                 document.getElementById("errorMessage").style.display = "block";


### PR DESCRIPTION
Set user name and password from Jenkins side and try to launch wizard directly without login again.

When open the job wizard again, the device/app/settings are selected by previous job info.