### PR TITLE
Fix for an issue with using LoadRuner with underscore in the name

### DIFF
--- a/src/main/java/com/hp/application/automation/tools/results/PerformanceJobReportAction.java
+++ b/src/main/java/com/hp/application/automation/tools/results/PerformanceJobReportAction.java
@@ -59,7 +59,7 @@ public class PerformanceJobReportAction extends InvisibleAction implements Simpl
     }
 
     /**
-     * Merge results of several runs - espcially useful in pipeline jobs with multiple LR steps
+     * Merge results of several runs - especially useful in pipeline jobs with multiple LR steps
      *
      * @param resultFiles the result files
      */

--- a/src/main/java/com/hp/application/automation/tools/results/RunResultRecorder.java
+++ b/src/main/java/com/hp/application/automation/tools/results/RunResultRecorder.java
@@ -857,58 +857,60 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
         writer.close();
 
         File indexFile = new File(reportDirectory, REPORT_INDEX_NAME);
-        writer = new BufferedWriter(new FileWriter(indexFile));
-
-        Iterator<SuiteResult> resultIterator = null;
-        if ((testResult != null) && (!testResult.getSuites().isEmpty())) {
-            resultIterator = testResult.getSuites().iterator();//get the first
-        }
-        for (String report : reportNames) {
-            SuiteResult suitResult = null;
-            if ((resultIterator != null) && resultIterator.hasNext()) {
-                suitResult = resultIterator.next();
+        try {
+            writer = new BufferedWriter(new FileWriter(indexFile));
+            Iterator<SuiteResult> resultIterator = null;
+            if ((testResult != null) && (!testResult.getSuites().isEmpty())) {
+                resultIterator = testResult.getSuites().iterator();//get the first
             }
-            if (suitResult == null) {
-                writer.write(report + "\t##\t##\t##%n");
-            } else {
-                int iDuration = (int) suitResult.getDuration();
-                StringBuilder bld = new StringBuilder();
-                String duration = "";
-                if ((iDuration / SECS_IN_DAY) > 0) {
-                    bld.append(String.format("%dday ", iDuration / SECS_IN_DAY));
-                    iDuration = iDuration % SECS_IN_DAY;
+            for (String report : reportNames) {
+                SuiteResult suitResult = null;
+                if ((resultIterator != null) && resultIterator.hasNext()) {
+                    suitResult = resultIterator.next();
                 }
-                if ((iDuration / SECS_IN_HOUR) > 0) {
-                    bld.append(String.format("%02dhr ", iDuration / SECS_IN_HOUR));
-                    iDuration = iDuration % SECS_IN_HOUR;
-                } else if (!duration.isEmpty()) {
-                    bld.append("00hr ");
+                if (suitResult == null) {
+                    writer.write(report + "\t##\t##\t##%n");
+                } else {
+                    int iDuration = (int) suitResult.getDuration();
+                    StringBuilder bld = new StringBuilder();
+                    String duration = "";
+                    if ((iDuration / SECS_IN_DAY) > 0) {
+                        bld.append(String.format("%dday ", iDuration / SECS_IN_DAY));
+                        iDuration = iDuration % SECS_IN_DAY;
+                    }
+                    if ((iDuration / SECS_IN_HOUR) > 0) {
+                        bld.append(String.format("%02dhr ", iDuration / SECS_IN_HOUR));
+                        iDuration = iDuration % SECS_IN_HOUR;
+                    } else if (!duration.isEmpty()) {
+                        bld.append("00hr ");
+                    }
+                    if ((iDuration / SECS_IN_MINUTE) > 0) {
+                        bld.append(String.format("%02dmin ", iDuration / SECS_IN_MINUTE));
+                        iDuration = iDuration % SECS_IN_MINUTE;
+                    } else if (!duration.isEmpty()) {
+                        bld.append("00min ");
+                    }
+                    bld.append(String.format("%02dsec", iDuration));
+                    duration = bld.toString();
+                    int iPassCount = 0;
+                    int iFailCount = 0;
+                    for (Iterator i = suitResult.getCases().iterator(); i.hasNext(); ) {
+                        CaseResult caseResult = (CaseResult) i.next();
+                        iPassCount += caseResult.getPassCount();
+                        iFailCount += caseResult.getFailCount();
+                    }
+                    writer.write(
+                            String.format("%s\t%s\t%d\t%d%n",
+                                    report,
+                                    duration,
+                                    iPassCount,
+                                    iFailCount));
                 }
-                if ((iDuration / SECS_IN_MINUTE) > 0) {
-                    bld.append(String.format("%02dmin ", iDuration / SECS_IN_MINUTE));
-                    iDuration = iDuration % SECS_IN_MINUTE;
-                } else if (!duration.isEmpty()) {
-                    bld.append("00min ");
-                }
-                bld.append(String.format("%02dsec", iDuration));
-                duration = bld.toString();
-                int iPassCount = 0;
-                int iFailCount = 0;
-                for (Iterator i = suitResult.getCases().iterator(); i.hasNext(); ) {
-                    CaseResult caseResult = (CaseResult) i.next();
-                    iPassCount += caseResult.getPassCount();
-                    iFailCount += caseResult.getFailCount();
-                }
-                writer.write(
-                        String.format("%s\t%s\t%d\t%d%n",
-                                report,
-                                duration,
-                                iPassCount,
-                                iFailCount));
             }
+        } finally {
+            writer.flush();
+            writer.close();
         }
-        writer.flush();
-        writer.close();
     }
 
     /**

--- a/src/main/java/com/hp/application/automation/tools/results/RunResultRecorder.java
+++ b/src/main/java/com/hp/application/automation/tools/results/RunResultRecorder.java
@@ -655,6 +655,15 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
         return true;
     }
 
+    /**
+     * Copies the run report from the executing node to the Jenkins master for processing.
+     * @param reportFolder
+     * @param buildDir
+     * @param scenarioName
+     * @return
+     * @throws IOException
+     * @throws InterruptedException
+     */
     private FilePath copyRunReport(FilePath reportFolder, File buildDir, String
             scenarioName)
             throws IOException, InterruptedException {

--- a/src/main/java/com/hp/application/automation/tools/results/RunResultRecorder.java
+++ b/src/main/java/com/hp/application/automation/tools/results/RunResultRecorder.java
@@ -110,8 +110,8 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
     private static final String REPORTMETADATE_XML = "report_metadata.xml";
     private static final String TRANSACTION_SUMMARY_FOLDER = "TransactionSummary";
     private static final String TRANSACTION_REPORT_NAME = "Report3";
-    public static final String SLA_ACTUAL_VALUE_LABEL = "ActualValue";
-    public static final String SLA_GOAL_VALUE_LABEL = "GoalValue";
+    private static final String SLA_ACTUAL_VALUE_LABEL = "ActualValue";
+    private static final String SLA_GOAL_VALUE_LABEL = "GoalValue";
     public static final String SLA_ULL_NAME = "FullName";
     public static final String ARCHIVING_TEST_REPORTS_FAILED_DUE_TO_XML_PARSING_ERROR =
             "Archiving test reports failed due to xml parsing error: ";
@@ -304,9 +304,9 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
      */
 
         // add previous report names for aggregation when using pipelines.
-        for (SuiteResult suiteResult : testResult.getSuites()) {
-            String[] temp = suiteResult.getName().split("_");
-            reportNames.add(temp[temp.length - 1]);
+        PerformanceJobReportAction performanceJobReportAction = build.getAction(PerformanceJobReportAction.class);
+        if (performanceJobReportAction != null){
+            reportNames.addAll(performanceJobReportAction.getLrResultBuildDataset().getLrScenarioResults().keySet());
         }
 
         for (String resultsFilePath : resultFiles) {
@@ -332,6 +332,9 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
                         continue;
                     }
                     String testFolderPath = testSuiteElement.getAttribute("name");
+                    int testPathArr = testFolderPath.lastIndexOf('\\');
+                    String testName = testFolderPath.substring(testPathArr + 1);
+                    reportNames.add(testName);
                     String testStatus = ("0".equals(testSuiteElement.getAttribute("failures"))) ? "pass" : "fail";
 
                     Node testCaseNode = testSuiteElement.getElementsByTagName("testcase").item(0);

--- a/src/main/java/com/hp/application/automation/tools/results/RunResultRecorder.java
+++ b/src/main/java/com/hp/application/automation/tools/results/RunResultRecorder.java
@@ -367,9 +367,13 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
                         try {
                             FilePath testSla = copyRunReport(reportFolder, build.getRootDir(),
                                     testFolder.getName());
-                            runReportList.add(testSla);
+                            if(testSla == null){
+                                listener.getLogger().println("no RunReport.xml file was created");
+                            } else {
+                                runReportList.add(testSla);
+                            }
                         } catch (IOException | InterruptedException e) {
-                            listener.getLogger().println(e.getMessage());
+                            listener.getLogger().println(e);
                         }
                     }
                 }
@@ -652,7 +656,7 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
     }
 
     private FilePath copyRunReport(FilePath reportFolder, File buildDir, String
-            scenerioName)
+            scenarioName)
             throws IOException, InterruptedException {
         FilePath slaReportFilePath = new FilePath(reportFolder, "RunReport.xml");
         if (slaReportFilePath.exists()) {
@@ -671,13 +675,13 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
             tmpZipFile.unzip(slaDirectoryFilePath);
             FilePath slaFile = new FilePath(slaDirectoryFilePath, "RunReport.xml");
             slaFile.getBaseName();
-            slaFile.renameTo(new FilePath(slaDirectoryFilePath, scenerioName + ".xml"));
+            slaFile.renameTo(new FilePath(slaDirectoryFilePath, scenarioName + ".xml"));
 
-            slaFile = new FilePath(slaDirectoryFilePath, scenerioName + ".xml");
+            slaFile = new FilePath(slaDirectoryFilePath, scenarioName + ".xml");
 
             return slaFile;
         }
-        throw (new IOException("no RunReport.xml file was created"));
+        return null;
     }
 
     private boolean archiveFolder(FilePath reportFolder,
@@ -995,7 +999,6 @@ public class RunResultRecorder extends Recorder implements Serializable, MatrixA
         DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
 
         Document doc = dBuilder.parse(slaFilePath.read());
-//		doc.getDocumentElement().normalize();
 
         processSLA(jobLrScenarioResult, doc);
         processLrScenarioStats(jobLrScenarioResult, doc);


### PR DESCRIPTION
- Fix for an issue in case the user uses LR scenarios with underscore in the name which will cause the performance and transaction report to return 404.

- The issue was caused due to JUnit archiver plugin used to parse the result sanitizes the file name string and causes the suite name which the folder path to appear one long file name instead of a regular path to scenario. This is later used to represent the scenario in the index files of the reports.
**Jira ticket: https://issues.jenkins-ci.org/browse/JENKINS-40222**
