### PR TITLE
Add support for gherkin formatter version 12.53.22 (along with versio…

### DIFF
--- a/src/main/java/com/hp/application/automation/tools/octane/actions/cucumber/CucumberResultsService.java
+++ b/src/main/java/com/hp/application/automation/tools/octane/actions/cucumber/CucumberResultsService.java
@@ -35,7 +35,7 @@ public class CucumberResultsService {
 
     public static final String GHERKIN_NGA_RESULTS_XML = "OctaneGherkinResults.xml";
     public static final String GHERKIN_NGA_RESULTS = "OctaneGherkinResults";
-    public static final String DEFAULT_GLOB = "**/" + GHERKIN_NGA_RESULTS_XML;
+    public static final String DEFAULT_GLOB = "**/*" + GHERKIN_NGA_RESULTS_XML;
 
     private static BuildListener listener;
 

--- a/src/main/java/com/hp/application/automation/tools/octane/actions/cucumber/CucumberResultsService.java
+++ b/src/main/java/com/hp/application/automation/tools/octane/actions/cucumber/CucumberResultsService.java
@@ -29,7 +29,7 @@ import java.io.*;
 import java.nio.file.Files;
 
 /**
- * Created by franksha on 22/03/2016.
+ * Helper Service for Gherkin results
  */
 public class CucumberResultsService {
 


### PR DESCRIPTION
Add support for gherkin formatter version 12.53.22 (along with version 12.53.19) - change the default glob to **/*OctaneGherkinResults.xml
The default glob was **/OctaneGherkinResults.xml. I added the extra * to support the new formatter version that creates unique file names with the OctaneGherkinResults.xml postfix.


Please Make sure these boxes are checked before submitting your pull request - Thanks ahead!

- [V ] Proper pull request title - concise and clear for others.
- [ V] Proper pull request short description - clear and concise (as it should appear in the Jira ticket) for other developers and users.
- [ X] Proper Jira ticket - Number, Link in pull request description.
- [V ] The PR can is merged on your machine without any conflicts.
- [V ] The PR can is built on your machine without any (new) warnings.
- [V ] The PR passed sanity tests by you / QA / DevTest / Good Samaritain.
- [ X] Add unit tests with new features.
- [X ] If you added any dependency to the POM - Please update @YafimK
