### PR TITLE
Using SVConfigurator 4.00.1.46729 to fix connectivity to SV 4.00

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,10 +291,6 @@
 			<url>http://repo1.maven.org/maven2</url>
 		</repository>
 		<repository>
-			<id>hp-application-automation-tools-plugin-mvn-repo</id>
-			<url>https://raw.github.com/HpeServiceVirtualization/3g/mvn-repo/</url>
-		</repository>
-		<repository>
 			<id>bintray-adm-maven</id>
 			<name>bintray</name>
 			<url>http://dl.bintray.com/adm/maven</url>
@@ -377,7 +373,7 @@
 		<dependency>
 			<groupId>com.hp.sv</groupId>
 			<artifactId>SVConfigurator</artifactId>
-			<version>3.82.1.45909</version>
+			<version>4.00.1.46729</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-io</groupId>


### PR DESCRIPTION
- using SVConfigurator 4.00.1.46729 to fix connectivity to SV 4.00
- using SVConfigurator from bintray-adm-maven instad of github.com maven repo
Related defect: https://issues.jenkins-ci.org/browse/JENKINS-43232
