### PR TITLE
Small workaround to fix No data status on transactions due to Analysis Api issue

### DIFF
--- a/LRAnalysisLauncher/Program.cs
+++ b/LRAnalysisLauncher/Program.cs
@@ -298,6 +298,9 @@ namespace LRAnalysisLauncher
                             }
                             XmlElement timeRanges = xmlDoc.CreateElement("TimeRanges");
                             log("TimeRanges : " + b.TimeRanges.Count);
+                            int passed = 0;
+                            int failed = 0;
+                            int noData = 0;
                             foreach (SlaTimeRangeInfo slatri in b.TimeRanges)
                             {
                                 XmlElement subsubelem = xmlDoc.CreateElement("TimeRangeInfo");
@@ -307,12 +310,32 @@ namespace LRAnalysisLauncher
                                 subsubelem.SetAttribute("ActualValue", slatri.ActualValue.ToString(formatProvider));
                                 subsubelem.SetAttribute("LoadValue", slatri.LoadValue.ToString(formatProvider));
                                 subsubelem.InnerText = slatri.Status.ToString();
+                                switch (slatri.Status)
+                                {
+                                    case SlaRuleStatus.Failed:
+                                        failed++;
+                                        break;
+                                    case SlaRuleStatus.Passed:
+                                        passed++;
+                                        break;
+                                    case SlaRuleStatus.NoData:
+                                        noData++;
+                                        break;
+                                }
                                 timeRanges.AppendChild(subsubelem);
                             }
                             rule.AppendChild(timeRanges);
-                            log("status : " + b.Status);
-                            rule.AppendChild(xmlDoc.CreateTextNode(b.Status.ToString()));
-                            if (b.Status.Equals(SlaRuleStatus.Failed)) // 0 = failed
+                            SlaRuleStatus currentRuleStatus = b.Status;
+                            if (currentRuleStatus.Equals(SlaRuleStatus.NoData))
+                            {
+                                if (passed > noData)
+                                {
+                                    currentRuleStatus = SlaRuleStatus.Passed;
+                                }
+                            }
+                            log("status : " + currentRuleStatus);
+                            rule.AppendChild(xmlDoc.CreateTextNode(currentRuleStatus.ToString()));
+                            if (currentRuleStatus.Equals(SlaRuleStatus.Failed)) // 0 = failed
                             {
                                 iPassed = (int)Launcher.ExitCodeEnum.Failed;
                             }
@@ -339,6 +362,9 @@ namespace LRAnalysisLauncher
                             }
                             XmlElement timeRanges = xmlDoc.CreateElement("TimeRanges");
                             log("TimeRanges : " + a.TimeRanges.Count);
+                            int passed = 0;
+                            int failed = 0;
+                            int noData = 0;
                             foreach (SlaTimeRangeInfo slatri in a.TimeRanges)
                             {
                                 XmlElement subsubelem = xmlDoc.CreateElement("TimeRangeInfo");
@@ -348,12 +374,32 @@ namespace LRAnalysisLauncher
                                 subsubelem.SetAttribute("ActualValue", slatri.ActualValue.ToString(formatProvider));
                                 subsubelem.SetAttribute("LoadValue", slatri.LoadValue.ToString(formatProvider));
                                 subsubelem.InnerText = slatri.Status.ToString();
+                                switch (slatri.Status)
+                                {
+                                    case SlaRuleStatus.Failed:
+                                        failed++;
+                                        break;
+                                    case SlaRuleStatus.Passed:
+                                        passed++;
+                                        break;
+                                    case SlaRuleStatus.NoData:
+                                        noData++;
+                                        break;
+                                }
                                 timeRanges.AppendChild(subsubelem);
                             }
                             rule.AppendChild(timeRanges);
-                            log("status : " + a.Status);
-                            rule.AppendChild(xmlDoc.CreateTextNode(a.Status.ToString()));
-                            if (a.Status.Equals(SlaRuleStatus.Failed))
+                            SlaRuleStatus currentRuleStatus = a.Status;
+                            if (currentRuleStatus.Equals(SlaRuleStatus.NoData))
+                            {
+                                if (passed > noData)
+                                {
+                                    currentRuleStatus = SlaRuleStatus.Passed;
+                                }
+                            }
+                            log("status : " + currentRuleStatus);
+                            rule.AppendChild(xmlDoc.CreateTextNode(currentRuleStatus.ToString()));
+                            if (currentRuleStatus.Equals(SlaRuleStatus.Failed))
                             {
                                 iPassed = (int)Launcher.ExitCodeEnum.Failed;
                             }

--- a/LRAnalysisLauncher/Program.cs
+++ b/LRAnalysisLauncher/Program.cs
@@ -326,12 +326,9 @@ namespace LRAnalysisLauncher
                             }
                             rule.AppendChild(timeRanges);
                             SlaRuleStatus currentRuleStatus = b.Status;
-                            if (currentRuleStatus.Equals(SlaRuleStatus.NoData))
+                            if (currentRuleStatus.Equals(SlaRuleStatus.NoData) && (passed > noData))
                             {
-                                if (passed > noData)
-                                {
-                                    currentRuleStatus = SlaRuleStatus.Passed;
-                                }
+                                currentRuleStatus = SlaRuleStatus.Passed;
                             }
                             log("status : " + currentRuleStatus);
                             rule.AppendChild(xmlDoc.CreateTextNode(currentRuleStatus.ToString()));
@@ -390,12 +387,9 @@ namespace LRAnalysisLauncher
                             }
                             rule.AppendChild(timeRanges);
                             SlaRuleStatus currentRuleStatus = a.Status;
-                            if (currentRuleStatus.Equals(SlaRuleStatus.NoData))
+                            if (currentRuleStatus.Equals(SlaRuleStatus.NoData) && (passed > noData))
                             {
-                                if (passed > noData)
-                                {
-                                    currentRuleStatus = SlaRuleStatus.Passed;
-                                }
+                                currentRuleStatus = SlaRuleStatus.Passed;
                             }
                             log("status : " + currentRuleStatus);
                             rule.AppendChild(xmlDoc.CreateTextNode(currentRuleStatus.ToString()));

--- a/LRAnalysisLauncher/Program.cs
+++ b/LRAnalysisLauncher/Program.cs
@@ -321,6 +321,8 @@ namespace LRAnalysisLauncher
                                     case SlaRuleStatus.NoData:
                                         noData++;
                                         break;
+                                    default:
+                                        break;
                                 }
                                 timeRanges.AppendChild(subsubelem);
                             }
@@ -381,6 +383,8 @@ namespace LRAnalysisLauncher
                                         break;
                                     case SlaRuleStatus.NoData:
                                         noData++;
+                                        break;
+                                    default:
                                         break;
                                 }
                                 timeRanges.AppendChild(subsubelem);


### PR DESCRIPTION
A LR run would get NoData status result on transactions due to having several time ranges with NoData results.
This will offer small fix to bypass cases in which the NoData status is given when there is several small number of NoData time ranges.
