### PR TITLE
defect #279005: [Gherkin] When all steps are skipped the scenarios an…

### DIFF
--- a/src/main/java/com/hp/application/automation/tools/octane/tests/gherkin/GherkinTestResultsCollector.java
+++ b/src/main/java/com/hp/application/automation/tools/octane/tests/gherkin/GherkinTestResultsCollector.java
@@ -167,7 +167,7 @@ public class GherkinTestResultsCollector {
                 duration += stepDuration;
 
                 String stepStatus = stepElement.getAttribute("status");
-                if (!statusDetermined && "pending".equals(stepStatus)) {
+                if (!statusDetermined && ("pending".equals(stepStatus) || "skipped".equals(stepStatus))) {
                     status = TestResultStatus.SKIPPED;
                     statusDetermined = true;
                 } else if (!statusDetermined && "failed".equals(stepStatus)) {


### PR DESCRIPTION
…d run status is Passed

When all steps of a gherkin test are skipped the scenarios and run status is Passed.
The problem:
The input xml was changed so instead of "pending" it is now "skipped"
Solution:
check for "skipped" too when determining the scenario status.