### PR TITLE
Rebranding fix in Jelly files depdendent on resources allocated by th…

### DIFF
--- a/src/main/resources/com/hpe/application/automation/tools/model/AutEnvironmentModel/config.jelly
+++ b/src/main/resources/com/hpe/application/automation/tools/model/AutEnvironmentModel/config.jelly
@@ -85,5 +85,5 @@
         <f:repeatableProperty field="autEnvironmentParameters" minimum="0" add="Add Parameter"/>
     </f:entry>
 
-    <script type="text/javascript" src="${rootURL}/plugin/hpe-application-automation-tools-plugin/autEnvironment.js"/>
+    <script type="text/javascript" src="${rootURL}/plugin/hp-application-automation-tools-plugin/autEnvironment.js"/>
 </j:jelly>

--- a/src/main/resources/com/hpe/application/automation/tools/results/HtmlBuildReportAction/index.jelly
+++ b/src/main/resources/com/hpe/application/automation/tools/results/HtmlBuildReportAction/index.jelly
@@ -53,11 +53,11 @@
            <tr>
              <j:choose>
                 <j:when test="${s.isHtmlReport}">
-                    <td class = "bodycell" align = "center"><img src="${rootURL}/plugin/hpe-application-automation-tools-plugin/icons/16x16/html_report.png" alt="Html_report" title="Html Report"/></td>
+                    <td class = "bodycell" align = "center"><img src="${rootURL}/plugin/hp-application-automation-tools-plugin/icons/16x16/html_report.png" alt="Html_report" title="Html Report"/></td>
                     <td class = "bodycell"><a href="../${s.urlName}" target="_blank">${s.disPlayName}</a></td>
                 </j:when>
                 <j:otherwise>
-                    <td class = "bodycell" align = "center"><img src="${rootURL}/plugin/hpe-application-automation-tools-plugin/icons/16x16/rrv_report.png" alt="RRV_report" title="RRV"/></td>
+                    <td class = "bodycell" align = "center"><img src="${rootURL}/plugin/hp-application-automation-tools-plugin/icons/16x16/rrv_report.png" alt="RRV_report" title="RRV"/></td>
                     <td class = "bodycell"><a href="../${s.urlName}">${s.disPlayName}</a></td>
                 </j:otherwise>
              </j:choose>
@@ -67,10 +67,10 @@
              <j:set var="status" value="${s.status}" />
              <j:choose>
                 <j:when test="${status=='pass'}">
-                    <td class = "bodycell" align = "center"><img src="${rootURL}/plugin/hpe-application-automation-tools-plugin/icons/16x16/passed.png" alt="Passed"/></td>
+                    <td class = "bodycell" align = "center"><img src="${rootURL}/plugin/hp-application-automation-tools-plugin/icons/16x16/passed.png" alt="Passed"/></td>
                 </j:when>
                 <j:otherwise>
-                    <td class = "bodycell" align = "center"><img src="${rootURL}/plugin/hpe-application-automation-tools-plugin/icons/16x16/failed.png" alt="Failed"/></td>
+                    <td class = "bodycell" align = "center"><img src="${rootURL}/plugin/hp-application-automation-tools-plugin/icons/16x16/failed.png" alt="Failed"/></td>
                 </j:otherwise>
              </j:choose>
 

--- a/src/main/resources/com/hpe/application/automation/tools/results/PerformanceProjectAction/index.jelly
+++ b/src/main/resources/com/hpe/application/automation/tools/results/PerformanceProjectAction/index.jelly
@@ -42,14 +42,14 @@
                   href="${resURL}/plugin/hpe-application-automation-tools-plugin/css/ColorPlate.css"></link>
             <link rel="stylesheet" type="text/css"
                   href="${resURL}/plugin/hpe-application-automation-tools-plugin/css/projectReport.css"></link>
-            <script src="${rootURL}/plugin/hpe-application-automation-tools-plugin/js/libaries/chartist/chartist.js"/>
-            <script src="${rootURL}/plugin/hpe-application-automation-tools-plugin/js/libaries/chartist/chartist-plugin-legend.js"/>
-            <script src="${rootURL}/plugin/hpe-application-automation-tools-plugin/js/libaries/chartist/chartist-plugin-tooltip.min.js"/>
-            <script src="${rootURL}/plugin/hpe-application-automation-tools-plugin/js/libaries/chartist/chartist-plugin-axistitle.min.js"/>
-            <!--<script src="${rootURL}/plugin/hpe-application-automation-tools-plugin/js/libaries/react/react-with-addons.min.js"></script>-->
+            <script src="${rootURL}/plugin/hp-application-automation-tools-plugin/js/libaries/chartist/chartist.js"/>
+            <script src="${rootURL}/plugin/hp-application-automation-tools-plugin/js/libaries/chartist/chartist-plugin-legend.js"/>
+            <script src="${rootURL}/plugin/hp-application-automation-tools-plugin/js/libaries/chartist/chartist-plugin-tooltip.min.js"/>
+            <script src="${rootURL}/plugin/hp-application-automation-tools-plugin/js/libaries/chartist/chartist-plugin-axistitle.min.js"/>
+            <!--<script src="${rootURL}/plugin/hp-application-automation-tools-plugin/js/libaries/react/react-with-addons.min.js"></script>-->
             <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react-with-addons.js"></script>
             <script
-                    src="${rootURL}/plugin/hpe-application-automation-tools-plugin/js/libaries/react/react-dom.js"></script>
+                    src="${rootURL}/plugin/hp-application-automation-tools-plugin/js/libaries/react/react-dom.js"></script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.38/browser.js"></script>
             <st:bind var="graphData" value="${it.GraphData}"/>
 
@@ -69,9 +69,9 @@
             <div class="scenarioSummary"></div>
             <div class="graphCon"></div>
 
-            <script type="text/javascript" src="${rootURL}/plugin/hpe-application-automation-tools-plugin/js/jslib.js"/>
+            <script type="text/javascript" src="${rootURL}/plugin/hp-application-automation-tools-plugin/js/jslib.js"/>
             <script type="text/babel"
-                    src="${rootURL}/plugin/hpe-application-automation-tools-plugin/js/dropdown.jsx"></script>
+                    src="${rootURL}/plugin/hp-application-automation-tools-plugin/js/dropdown.jsx"></script>
         </l:main-panel>
     </l:layout>
 </j:jelly>

--- a/src/main/resources/com/hpe/application/automation/tools/results/lrscriptresultparser/LrScriptHtmlReportAction/index.jelly
+++ b/src/main/resources/com/hpe/application/automation/tools/results/lrscriptresultparser/LrScriptHtmlReportAction/index.jelly
@@ -49,7 +49,7 @@
 
          <j:forEach var="s" items="${it.allReports}">
            <tr>
-            <td class = "bodycell" align = "center"><img src="${rootURL}/plugin/hpe-application-automation-tools-plugin/icons/16x16/html_report.png" alt="Html_report" title="Html Report"/></td>
+            <td class = "bodycell" align = "center"><img src="${rootURL}/plugin/hp-application-automation-tools-plugin/icons/16x16/html_report.png" alt="Html_report" title="Html Report"/></td>
             <td class = "bodycell"><a href="../${s.htmlUrl}" target="_blank">${s.scriptName}</a></td>
                <td class="bodycell">
                    <a href="../${s.scriptFolderPath}">Open ${s.scriptName} result</a>

--- a/src/main/resources/com/hpe/application/automation/tools/run/RunFromFileBuilder/config.jelly
+++ b/src/main/resources/com/hpe/application/automation/tools/run/RunFromFileBuilder/config.jelly
@@ -30,7 +30,7 @@
             }
         }
     </script>
-    <script type="text/javascript" src="${rootURL}/plugin/hpe-application-automation-tools-plugin/configure.js"/>
+    <script type="text/javascript" src="${rootURL}/plugin/hp-application-automation-tools-plugin/configure.js"/>
 
     <f:entry title="Tests" field="fsTests">
         <f:expandableTextbox name="runfromfs.fsTests" value="${instance.runFromFileModel.fsTests}"/>


### PR DESCRIPTION
Several Jelly files are dependent of locating resources by plugin artifact ID and therefore need the original artifact id remain in their code.