### PR TITLE
PC integration with Octane (#14)

### DIFF
--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/HPRunnerType.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/HPRunnerType.java
@@ -17,10 +17,11 @@
 package com.hpe.application.automation.tools.octane.tests;
 
 /**
- * Created by franksha on 05/01/2017.
+ * Runner type of test
  */
 public enum HPRunnerType {
     StormRunner,
     UFT,
+    PerformanceCenter,
     NONE
 }

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/TestListener.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/TestListener.java
@@ -36,6 +36,9 @@ import org.apache.logging.log4j.Logger;
 import javax.xml.stream.XMLStreamException;
 import java.util.List;
 
+/**
+ * Jenkins events life cycle listener for processing test results on build completed
+ */
 @Extension
 @SuppressWarnings({"squid:S2699","squid:S3658","squid:S2259","squid:S1872"})
 public class TestListener {
@@ -43,6 +46,8 @@ public class TestListener {
 
 	static final String TEST_RESULT_FILE = "mqmTests.xml";
 	public static final String JENKINS_STORM_TEST_RUNNER_CLASS = "com.hpe.sr.plugins.jenkins.StormTestRunner";
+	public static final String JENKINS_PERFORMANCE_CENTER_TEST_RUNNER_CLASS = "com.hpe.application.automation.tools.run.PcBuilder";
+
 
 	private ResultQueue queue;
 
@@ -63,6 +68,10 @@ public class TestListener {
 				}
 				if (builder.getClass().getName().equals(UFTExtension.RUN_FROM_FILE_BUILDER) || builder.getClass().getName().equals(UFTExtension.RUN_FROM_ALM_BUILDER)) {
 					hpRunnerType = HPRunnerType.UFT;
+					break;
+				}
+				if (builder.getClass().getName().equals(JENKINS_PERFORMANCE_CENTER_TEST_RUNNER_CLASS)) {
+					hpRunnerType = HPRunnerType.PerformanceCenter;
 					break;
 				}
 			}

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/detection/ResultFields.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/detection/ResultFields.java
@@ -16,20 +16,28 @@
 
 package com.hpe.application.automation.tools.octane.tests.detection;
 
-
+/**
+ * Class describing metadata of executed tests for test pushing to Octane
+ */
 public class ResultFields {
 
     private String framework;
     private String testingTool;
     private String testLevel;
+    private String testType;
 
     public ResultFields() {
     }
 
     public ResultFields(final String framework, final String testingTool, final String testLevel) {
+        this(framework, testingTool, testLevel, null);
+    }
+
+    public ResultFields(final String framework, final String testingTool, final String testLevel, final String testType) {
         this.framework = framework;
         this.testingTool = testingTool;
         this.testLevel = testLevel;
+        this.testType = testType;
     }
 
     public String getFramework() {
@@ -73,6 +81,10 @@ public class ResultFields {
         if (testingTool != null ? !testingTool.equals(that.testingTool) : that.testingTool != null) {
             return false;
         }
+
+        if (testType != null ? !testType.equals(that.testType) : that.testType != null) {
+            return false;
+        }
         return !(testLevel != null ? !testLevel.equals(that.testLevel) : that.testLevel != null);
 
     }
@@ -82,6 +94,15 @@ public class ResultFields {
         int result = framework != null ? framework.hashCode() : 0;
         result = 31 * result + (testingTool != null ? testingTool.hashCode() : 0);
         result = 31 * result + (testLevel != null ? testLevel.hashCode() : 0);
+        result = 31 * result + (testType != null ? testType.hashCode() : 0);
         return result;
+    }
+
+    public String getTestType() {
+        return testType;
+    }
+
+    public void setTestType(String testType) {
+        this.testType = testType;
     }
 }

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitTestResult.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitTestResult.java
@@ -22,6 +22,9 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import java.io.Serializable;
 
+/**
+ * Test Run XML writer to mqmTests.xml
+ */
 final public class JUnitTestResult implements Serializable, TestResult {
 
     private final String moduleName;

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitXmlIterator.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitXmlIterator.java
@@ -16,12 +16,12 @@
 
 package com.hpe.application.automation.tools.octane.tests.junit;
 
-import com.hpe.application.automation.tools.octane.executor.OctaneConstants;
-import com.hpe.application.automation.tools.octane.tests.HPRunnerType;
-import com.hpe.application.automation.tools.octane.tests.xml.AbstractXmlIterator;
 import com.hp.octane.integrations.dto.DTOFactory;
 import com.hp.octane.integrations.dto.tests.Property;
 import com.hp.octane.integrations.dto.tests.TestSuite;
+import com.hpe.application.automation.tools.octane.executor.OctaneConstants;
+import com.hpe.application.automation.tools.octane.tests.HPRunnerType;
+import com.hpe.application.automation.tools.octane.tests.xml.AbstractXmlIterator;
 import hudson.FilePath;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -40,7 +40,7 @@ import java.text.ParseException;
 import java.util.List;
 
 /**
- * JUnit iterator over test result. Enrich test result before sending to server
+ * JUnit result parser and enricher according to HPRunnerType
  */
 public class JUnitXmlIterator extends AbstractXmlIterator<JUnitTestResult> {
 	private static final Logger logger = LogManager.getLogger(JUnitXmlIterator.class);
@@ -169,8 +169,10 @@ public class JUnitXmlIterator extends AbstractXmlIterator<JUnitTestResult> {
 						}
 					}
 					externalURL = jenkinsRootUrl + "job/" + jobName + "/" + buildId + "/artifact/UFTReport/" + cleanTestName(testName) + "/run_results.html";
-				}
-			} else if ("duration".equals(localName)) { // NON-NLS
+                } else if (hpRunnerType.equals(HPRunnerType.PerformanceCenter)) {
+                    externalURL = jenkinsRootUrl + "job/" + jobName + "/" + buildId + "/artifact/performanceTestsReports/pcRun/Report.html";
+                }
+            } else if ("duration".equals(localName)) { // NON-NLS
 				duration = parseTime(readNextValue());
 			} else if ("skipped".equals(localName)) { // NON-NLS
 				if ("true".equals(readNextValue())) { // NON-NLS

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/xml/TestResultXmlWriter.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/xml/TestResultXmlWriter.java
@@ -34,6 +34,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Iterator;
 
+/**
+ * Save results to mqmTests.xml in XML format
+ */
 @SuppressWarnings("all")
 public class TestResultXmlWriter {
 
@@ -107,12 +110,13 @@ public class TestResultXmlWriter {
 			writeField("Framework", resultFields.getFramework());
 			writeField("Test_Level", resultFields.getTestLevel());
 			writeField("Testing_Tool_Type", resultFields.getTestingTool());
+			writeField("Test_Type", resultFields.getTestType());
 			writer.writeEndElement();
 		}
 	}
 
 	private void writeField(String type, String value) throws XMLStreamException {
-		if (value != null) {
+		if (StringUtils.isNotEmpty(value)) {
 			writer.writeStartElement("test_field");
 			writer.writeAttribute("type", type);
 			writer.writeAttribute("value", value);

--- a/src/main/java/com/hpe/application/automation/tools/pc/PcClient.java
+++ b/src/main/java/com/hpe/application/automation/tools/pc/PcClient.java
@@ -30,13 +30,13 @@ package com.hpe.application.automation.tools.pc;
 
 import hudson.FilePath;
 
+import java.beans.IntrospectionException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.file.*;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.*;
 
 import hudson.console.HyperlinkNote;
 import org.apache.commons.io.IOUtils;
@@ -173,6 +173,11 @@ public class PcClient {
             }
         }
 
+    }
+
+    public String getTestName()  throws IOException, PcException{
+        PcTest pcTest = restProxy.getTestData(Integer.parseInt(model.getTestId()));
+        return pcTest.getTestName();
     }
 
     public PcRunResponse waitForRunCompletion(int runId) throws InterruptedException, ClientProtocolException, PcException, IOException {
@@ -376,5 +381,59 @@ public class PcClient {
 
     }
 
+
+    // This method will return a map with the following structure: <transaction_name:selected_measurement_value>
+    // for example:
+    // <Action_Transaction:0.001>
+    // <Virtual transaction 2:0.51>
+    // This function uses reflection since we know only at runtime which transactions data will be reposed from the rest request.
+    public Map<String, String>  getTrendReportByXML(String trendReportId, int runId, TrendReportTypes.DataType dataType, TrendReportTypes.PctType pctType,TrendReportTypes.Measurement measurement) throws IOException, PcException, IntrospectionException, NoSuchMethodException {
+
+        Map<String, String> measurmentsMap = new LinkedHashMap<String, String>();
+        measurmentsMap.put("RunId","_" + runId + "_");
+        measurmentsMap.put("Trend Measurement Type",measurement.toString() + "_" + pctType.toString());
+
+
+
+            TrendReportTransactionDataRoot res = restProxy.getTrendReportByXML(trendReportId, runId);
+
+//            java.lang.reflect.Method rootMethod =  res.getClass().getMethod("getTrendReport" + dataType.toString() + "DataRowsList");
+//            ArrayList<Object> RowsListObj = (ArrayList<Object>) rootMethod.invoke(res);
+//            RowsListObj.get(0);
+
+            List<Object> RowsListObj = res.getTrendReportRoot();
+
+            for (int i=0; i< RowsListObj.size();i++){
+                try {
+
+                    java.lang.reflect.Method rowListMethod = RowsListObj.get(i).getClass().getMethod("getTrendReport" + dataType.toString() + "DataRowList");
+
+                for ( Object DataRowObj : (ArrayList<Object>)rowListMethod.invoke(RowsListObj.get(i)))
+                {
+                    if (DataRowObj.getClass().getMethod("getPCT_TYPE").invoke(DataRowObj).equals(pctType.toString()))
+                    {
+                        java.lang.reflect.Method method;
+                        method = DataRowObj.getClass().getMethod("get" + measurement.toString());
+                        measurmentsMap.put(DataRowObj.getClass().getMethod("getPCT_NAME").invoke(DataRowObj).toString(),method.invoke(DataRowObj)==null?"":method.invoke(DataRowObj).toString());
+                    }
+                }
+                }catch (NoSuchMethodException e){
+                  //  logger.println("No such method exception: " + e);
+                }
+                catch (Exception e){
+                    logger.println("Error on getTrendReportByXML: " + e);
+                }
+            }
+
+
+
+
+          //  logger.print(res);
+
+
+        return measurmentsMap;
+
+
+    }
 
 }

--- a/src/main/java/com/hpe/application/automation/tools/pc/PcRestProxy.java
+++ b/src/main/java/com/hpe/application/automation/tools/pc/PcRestProxy.java
@@ -80,7 +80,7 @@ public class PcRestProxy {
     protected static final String        TREND_REPORT_RESOURCE_NAME     = "TrendReports";
     protected static final String        TREND_REPORT_RESOURCE_SUFFIX     = "data";
     protected static final String        CONTENT_TYPE_XML               = "application/xml";
-    static final String                  PC_API_XMLNS                   = "http://www.hp.com/PC/REST/API";
+    public static final String                  PC_API_XMLNS                   = "http://www.hp.com/PC/REST/API";
 	
     protected static final List<Integer> validStatusCodes = Arrays.asList(SC_OK, SC_CREATED, SC_ACCEPTED, SC_NO_CONTENT);
 	
@@ -251,12 +251,12 @@ public class PcRestProxy {
     }
 
 
-    public ArrayList<PcTrendedRun> getTrendReportMetaData (String trendReportId) throws PcException, ClientProtocolException, IOException {
-        String getTrendReportMetaDataUrl = String.format(baseURL + "/%s/%s", TREND_REPORT_RESOURCE_NAME, trendReportId);
-        HttpGet getTrendReportMetaDataRequest = new HttpGet(getTrendReportMetaDataUrl);
-        HttpResponse response = executeRequest(getTrendReportMetaDataRequest);
-        String trendReportMetaData = IOUtils.toString(response.getEntity().getContent());
-        return PcTrendReportMetaData.xmlToObject(trendReportMetaData);
+    public TrendReportTransactionDataRoot getTrendReportByXML (String trendReportId, int runId) throws PcException, ClientProtocolException, IOException {
+        String getTrendReportByXMLUrl = String.format(baseURL + "/%s/%s/%s", TREND_REPORT_RESOURCE_NAME, trendReportId,runId);
+        HttpGet getTrendReportByXMLRequest = new HttpGet(getTrendReportByXMLUrl);
+        HttpResponse response = executeRequest(getTrendReportByXMLRequest);
+        String trendReportByXML = IOUtils.toString(response.getEntity().getContent());
+        return TrendReportTransactionDataRoot.xmlToObject(trendReportByXML);
     }
 
 
@@ -283,6 +283,14 @@ public class PcRestProxy {
 
         return in;
 
+    }
+
+    public ArrayList<PcTrendedRun> getTrendReportMetaData (String trendReportId) throws PcException, ClientProtocolException, IOException {
+        String getTrendReportMetaDataUrl = String.format(baseURL + "/%s/%s", TREND_REPORT_RESOURCE_NAME, trendReportId);
+        HttpGet getTrendReportMetaDataRequest = new HttpGet(getTrendReportMetaDataUrl);
+        HttpResponse response = executeRequest(getTrendReportMetaDataRequest);
+        String trendReportMetaData = IOUtils.toString(response.getEntity().getContent());
+        return PcTrendReportMetaData.xmlToObject(trendReportMetaData);
     }
     
     public PcRunEventLog getRunEventLog(int runId) throws PcException, ClientProtocolException, IOException {

--- a/src/main/java/com/hpe/application/automation/tools/pc/TrendReportMonitorsDataRow.java
+++ b/src/main/java/com/hpe/application/automation/tools/pc/TrendReportMonitorsDataRow.java
@@ -1,0 +1,93 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016 Hewlett-Packard Development Company, L.P.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.hpe.application.automation.tools.pc;
+
+import com.thoughtworks.xstream.XStream;
+
+/**
+ * Holds Trending Monitor data
+ */
+public class TrendReportMonitorsDataRow {
+
+
+    private String PCT_TYPE;
+    private String PCT_NAME;
+    private String PCT_MINIMUM;
+    private String PCT_MAXIMUM;
+    private String PCT_AVERAGE;
+    private String PCT_MEDIAN;
+    private String PCT_STDDEVIATION;
+    private String PCT_COUNT1;
+    private String PCT_MACHINE;
+    private String PCT_SUM1;
+
+
+    public static TrendReportMonitorsDataRow xmlToObject(String xml)
+    {
+        XStream xstream = new XStream();
+        xstream.alias("MonitorsDataRow" , TrendReportMonitorsDataRow.class);
+        return (TrendReportMonitorsDataRow)xstream.fromXML(xml);
+    }
+
+
+    public String getPCT_TYPE() {
+        return PCT_TYPE;
+    }
+
+    public String getPCT_NAME() {
+        return PCT_NAME;
+    }
+
+    public String getPCT_MINIMUM() {
+        return PCT_MINIMUM;
+    }
+
+    public String getPCT_MAXIMUM() {
+        return PCT_MAXIMUM;
+    }
+
+    public String getPCT_AVERAGE() {
+        return PCT_AVERAGE;
+    }
+
+    public String getPCT_MEDIAN() {
+        return PCT_MEDIAN;
+    }
+
+    public String getPCT_STDDEVIATION() {
+        return PCT_STDDEVIATION;
+    }
+
+    public String getPCT_COUNT1() {
+        return PCT_COUNT1;
+    }
+
+    public String getPCT_SUM1() {
+        return PCT_SUM1;
+    }
+
+
+    public String getPCT_MACHINE() {
+        return PCT_MACHINE;
+    }
+}

--- a/src/main/java/com/hpe/application/automation/tools/pc/TrendReportMonitorsDataRows.java
+++ b/src/main/java/com/hpe/application/automation/tools/pc/TrendReportMonitorsDataRows.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016 Hewlett-Packard Development Company, L.P.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.hpe.application.automation.tools.pc;
+
+import com.thoughtworks.xstream.XStream;
+
+import java.util.ArrayList;
+
+/**
+ * Holds Trending Monitors
+ */
+public class TrendReportMonitorsDataRows {
+
+    private ArrayList<TrendReportMonitorsDataRow> trendReportMonitorsDataRowList;
+
+    public TrendReportMonitorsDataRows(){ trendReportMonitorsDataRowList = new ArrayList<TrendReportMonitorsDataRow>();}
+
+    public static TrendReportMonitorsDataRows xmlToObject(String xml)
+    {
+        XStream xstream = new XStream();
+        xstream.alias("MonitorsData" , TrendReportMonitorsDataRows.class);
+        xstream.alias("MonitorsDataRow" , TrendReportMonitorsDataRow.class);
+        xstream.addImplicitCollection(TrendReportMonitorsDataRows.class, "trendReportMonitorsDataRowList");
+        xstream.setClassLoader(TrendReportMonitorsDataRows.class.getClassLoader());
+        return (TrendReportMonitorsDataRows)xstream.fromXML(xml);
+    }
+
+    public ArrayList<TrendReportMonitorsDataRow> getTrendReportMonitorsDataRowList() {
+        return trendReportMonitorsDataRowList;
+    }
+
+}
+
+

--- a/src/main/java/com/hpe/application/automation/tools/pc/TrendReportRegularDataRow.java
+++ b/src/main/java/com/hpe/application/automation/tools/pc/TrendReportRegularDataRow.java
@@ -1,0 +1,83 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016 Hewlett-Packard Development Company, L.P.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.hpe.application.automation.tools.pc;
+
+import com.thoughtworks.xstream.XStream;
+
+/**
+ * Holds Trending Regular data
+ */
+public class TrendReportRegularDataRow {
+
+
+    private String PCT_TYPE;
+    private String PCT_NAME;
+    private String PCT_MINIMUM;
+    private String PCT_MAXIMUM;
+    private String PCT_AVERAGE;
+    private String PCT_MEDIAN;
+    private String PCT_STDDEVIATION;
+    private String PCT_SUM1;
+
+
+    public static TrendReportRegularDataRow xmlToObject(String xml)
+    {
+        XStream xstream = new XStream();
+        xstream.alias("RegularDataRow" , TrendReportRegularDataRow.class);
+        return (TrendReportRegularDataRow)xstream.fromXML(xml);
+    }
+
+
+    public String getPCT_TYPE() {
+        return PCT_TYPE;
+    }
+
+    public String getPCT_NAME() {
+        return PCT_NAME;
+    }
+
+    public String getPCT_MINIMUM() {
+        return PCT_MINIMUM;
+    }
+
+    public String getPCT_MAXIMUM() {
+        return PCT_MAXIMUM;
+    }
+
+    public String getPCT_AVERAGE() {
+        return PCT_AVERAGE;
+    }
+
+    public String getPCT_MEDIAN() {
+        return PCT_MEDIAN;
+    }
+
+    public String getPCT_STDDEVIATION() {
+        return PCT_STDDEVIATION;
+    }
+
+    public String getPCT_SUM1() {
+        return PCT_SUM1;
+    }
+
+}

--- a/src/main/java/com/hpe/application/automation/tools/pc/TrendReportRegularDataRows.java
+++ b/src/main/java/com/hpe/application/automation/tools/pc/TrendReportRegularDataRows.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016 Hewlett-Packard Development Company, L.P.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.hpe.application.automation.tools.pc;
+
+import com.thoughtworks.xstream.XStream;
+
+import java.util.ArrayList;
+
+/**
+ * Holds Trending Regular
+ */
+public class TrendReportRegularDataRows {
+
+    private ArrayList<TrendReportRegularDataRow> trendReportRegularDataRowList;
+
+    public TrendReportRegularDataRows(){ trendReportRegularDataRowList = new ArrayList<TrendReportRegularDataRow>();}
+
+    public static TrendReportRegularDataRows xmlToObject(String xml)
+    {
+        XStream xstream = new XStream();
+        xstream.alias("RegularData" , TrendReportRegularDataRows.class);
+        xstream.alias("RegularDataRow" , TrendReportRegularDataRow.class);
+        xstream.addImplicitCollection(TrendReportRegularDataRows.class, "trendReportRegularDataRowList");
+        xstream.setClassLoader(TrendReportRegularDataRows.class.getClassLoader());
+        return (TrendReportRegularDataRows)xstream.fromXML(xml);
+    }
+
+    public ArrayList<TrendReportRegularDataRow> getTrendReportRegularDataRowList() {
+        return trendReportRegularDataRowList;
+    }
+
+}
+
+

--- a/src/main/java/com/hpe/application/automation/tools/pc/TrendReportTransactionDataRoot.java
+++ b/src/main/java/com/hpe/application/automation/tools/pc/TrendReportTransactionDataRoot.java
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016 Hewlett-Packard Development Company, L.P.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.hpe.application.automation.tools.pc;
+
+import com.thoughtworks.xstream.XStream;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Holds Trending Root data
+ */
+public  class TrendReportTransactionDataRoot{
+
+    private List trendReportRoot;
+
+    public TrendReportTransactionDataRoot(){
+        trendReportRoot = new ArrayList();
+    }
+
+    public static TrendReportTransactionDataRoot xmlToObject(String xml)
+    {
+        XStream xstream = new XStream();
+        xstream.alias("Root" , TrendReportTransactionDataRoot.class);
+        xstream.alias("TransactionsData" , TrendReportTransactionDataRows.class);
+        xstream.alias("TransactionsDataRow" , TrendReportTransactionDataRow.class);
+        xstream.alias("MonitorsData" , TrendReportMonitorsDataRows.class);
+        xstream.alias("MonitorsDataRow" , TrendReportMonitorsDataRow.class);
+        xstream.alias("RegularData" , TrendReportRegularDataRows.class);
+        xstream.alias("RegularDataRow" , TrendReportRegularDataRow.class);
+        xstream.addImplicitCollection(TrendReportTransactionDataRoot.class, "trendReportRoot");
+        xstream.addImplicitCollection(TrendReportTransactionDataRows.class, "trendReportTransactionDataRowList");
+        xstream.addImplicitCollection(TrendReportMonitorsDataRows.class, "trendReportMonitorsDataRowList");
+        xstream.addImplicitCollection(TrendReportRegularDataRows.class, "trendReportRegularDataRowList");
+
+        xstream.setClassLoader(TrendReportTransactionDataRoot.class.getClassLoader());
+        return (TrendReportTransactionDataRoot)xstream.fromXML(xml);
+    }
+
+    public List getTrendReportRoot() {
+        return trendReportRoot;
+    }
+
+
+}

--- a/src/main/java/com/hpe/application/automation/tools/pc/TrendReportTransactionDataRow.java
+++ b/src/main/java/com/hpe/application/automation/tools/pc/TrendReportTransactionDataRow.java
@@ -1,0 +1,167 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016 Hewlett-Packard Development Company, L.P.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.hpe.application.automation.tools.pc;
+
+import com.thoughtworks.xstream.XStream;
+
+/**
+ * Holds Trending Transactions data
+ */
+public class TrendReportTransactionDataRow {
+
+//<PCT_TYPE>TRT</PCT_TYPE>
+//<PCT_NAME>Action_Transaction</PCT_NAME>
+//<PCT_MINIMUM>0</PCT_MINIMUM>
+//<PCT_MAXIMUM>0.001</PCT_MAXIMUM>
+//<PCT_AVERAGE>0.001</PCT_AVERAGE>
+//<PCT_MEDIAN>0.001</PCT_MEDIAN>
+//<PCT_STDDEVIATION>0</PCT_STDDEVIATION>
+//<PCT_COUNT1>40</PCT_COUNT1>
+//<PCT_SUM1>0.027</PCT_SUM1>
+//<PCT_PERCENTILE_25>0.001118</PCT_PERCENTILE_25>
+//<PCT_PERCENTILE_75>0.001118</PCT_PERCENTILE_75>
+//<PCT_PERCENTILE_90>0.001118</PCT_PERCENTILE_90>
+//<PCT_PERCENTILE_91>0.0004311</PCT_PERCENTILE_91>
+//<PCT_PERCENTILE_92>0.0004311</PCT_PERCENTILE_92>
+//<PCT_PERCENTILE_93>0.0004311</PCT_PERCENTILE_93>
+//<PCT_PERCENTILE_94>0.0004311</PCT_PERCENTILE_94>
+//<PCT_PERCENTILE_95>0.0004311</PCT_PERCENTILE_95>
+//<PCT_PERCENTILE_96>0.0004311</PCT_PERCENTILE_96>
+//<PCT_PERCENTILE_97>0.0004311</PCT_PERCENTILE_97>
+//<PCT_PERCENTILE_98>0.0004311</PCT_PERCENTILE_98>
+//<PCT_PERCENTILE_99>0.0004311</PCT_PERCENTILE_99>
+
+    private String PCT_TYPE;
+    private String PCT_NAME;
+    private String PCT_MINIMUM;
+    private String PCT_MAXIMUM;
+    private String PCT_AVERAGE;
+    private String PCT_MEDIAN;
+    private String PCT_STDDEVIATION;
+    private String PCT_COUNT1;
+    private String PCT_SUM1;
+    private String PCT_PERCENTILE_25;
+    private String PCT_PERCENTILE_75;
+    private String PCT_PERCENTILE_90;
+    private String PCT_PERCENTILE_91;
+    private String PCT_PERCENTILE_92;
+    private String PCT_PERCENTILE_93;
+    private String PCT_PERCENTILE_94;
+    private String PCT_PERCENTILE_95;
+    private String PCT_PERCENTILE_96;
+    private String PCT_PERCENTILE_97;
+    private String PCT_PERCENTILE_98;
+    private String PCT_PERCENTILE_99;
+
+    public static TrendReportTransactionDataRow xmlToObject(String xml)
+    {
+        XStream xstream = new XStream();
+        xstream.alias("TransactionsDataRow" , TrendReportTransactionDataRow.class);
+        return (TrendReportTransactionDataRow)xstream.fromXML(xml);
+    }
+
+
+    public String getPCT_TYPE() {
+        return PCT_TYPE;
+    }
+
+    public String getPCT_NAME() {
+        return PCT_NAME;
+    }
+
+    public String getPCT_MINIMUM() {
+        return PCT_MINIMUM;
+    }
+
+    public String getPCT_MAXIMUM() {
+        return PCT_MAXIMUM;
+    }
+
+    public String getPCT_AVERAGE() {
+        return PCT_AVERAGE;
+    }
+
+    public String getPCT_MEDIAN() {
+        return PCT_MEDIAN;
+    }
+
+    public String getPCT_STDDEVIATION() {
+        return PCT_STDDEVIATION;
+    }
+
+    public String getPCT_COUNT1() {
+        return PCT_COUNT1;
+    }
+
+    public String getPCT_SUM1() {
+        return PCT_SUM1;
+    }
+
+    public String getPCT_PERCENTILE_25() {
+        return PCT_PERCENTILE_25;
+    }
+
+    public String getPCT_PERCENTILE_75() {
+        return PCT_PERCENTILE_75;
+    }
+
+    public String getPCT_PERCENTILE_90() {
+        return PCT_PERCENTILE_90;
+    }
+
+    public String getPCT_PERCENTILE_91() {
+        return PCT_PERCENTILE_91;
+    }
+
+    public String getPCT_PERCENTILE_92() {
+        return PCT_PERCENTILE_92;
+    }
+
+    public String getPCT_PERCENTILE_93() {
+        return PCT_PERCENTILE_93;
+    }
+
+    public String getPCT_PERCENTILE_94() {
+        return PCT_PERCENTILE_94;
+    }
+
+    public String getPCT_PERCENTILE_95() {
+        return PCT_PERCENTILE_95;
+    }
+
+    public String getPCT_PERCENTILE_96() {
+        return PCT_PERCENTILE_96;
+    }
+
+    public String getPCT_PERCENTILE_97() {
+        return PCT_PERCENTILE_97;
+    }
+
+    public String getPCT_PERCENTILE_98() {
+        return PCT_PERCENTILE_98;
+    }
+
+    public String getPCT_PERCENTILE_99() {
+        return PCT_PERCENTILE_99;
+    }
+}

--- a/src/main/java/com/hpe/application/automation/tools/pc/TrendReportTransactionDataRows.java
+++ b/src/main/java/com/hpe/application/automation/tools/pc/TrendReportTransactionDataRows.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016 Hewlett-Packard Development Company, L.P.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.hpe.application.automation.tools.pc;
+
+import com.thoughtworks.xstream.XStream;
+
+import java.util.ArrayList;
+
+/**
+ * Holds Trending Transactions data
+ */
+public class TrendReportTransactionDataRows {
+
+    private ArrayList<TrendReportTransactionDataRow> trendReportTransactionDataRowList;
+
+    public TrendReportTransactionDataRows(){ trendReportTransactionDataRowList = new ArrayList<TrendReportTransactionDataRow>();}
+
+    public static TrendReportTransactionDataRows xmlToObject(String xml)
+    {
+        XStream xstream = new XStream();
+        xstream.alias("TransactionsData" , TrendReportTransactionDataRows.class);
+        xstream.alias("TransactionsDataRow" , TrendReportTransactionDataRow.class);
+        xstream.addImplicitCollection(TrendReportTransactionDataRows.class, "trendReportTransactionDataRowList");
+        xstream.setClassLoader(TrendReportTransactionDataRows.class.getClassLoader());
+        return (TrendReportTransactionDataRows)xstream.fromXML(xml);
+    }
+
+    public ArrayList<TrendReportTransactionDataRow> getTrendReportTransactionDataRowList() {
+        return trendReportTransactionDataRowList;
+    }
+
+}
+
+

--- a/src/main/java/com/hpe/application/automation/tools/pc/TrendReportTypes.java
+++ b/src/main/java/com/hpe/application/automation/tools/pc/TrendReportTypes.java
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016 Hewlett-Packard Development Company, L.P.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.hpe.application.automation.tools.pc;
+
+/**
+ * Holds Trending Types Enum
+ */
+public class TrendReportTypes {
+
+    public enum DataType {
+        Transaction, Monitors, Regular
+    }
+
+    public enum PctType {
+        TRT, TPS, TRS, UDP, VU, WEB
+    }
+
+    public enum Measurement{
+        getPCT_TYPE,
+        getPCT_NAME,
+        PCT_MINIMUM,
+        PCT_MAXIMUM,
+        PCT_AVERAGE,
+        PCT_MEDIAN,
+        PCT_STDDEVIATION,
+        PCT_COUNT1,
+        PCT_SUM1,
+        PCT_MACHINE,
+        PCT_PERCENTILE_25,
+        PCT_PERCENTILE_75,
+        PCT_PERCENTILE_90,
+        PCT_PERCENTILE_91,
+        PCT_PERCENTILE_92,
+        PCT_PERCENTILE_93,
+        PCT_PERCENTILE_94,
+        PCT_PERCENTILE_95,
+        PCT_PERCENTILE_96,
+        PCT_PERCENTILE_97,
+        PCT_PERCENTILE_98,
+        PCT_PERCENTILE_99
+    }
+}

--- a/src/main/resources/com/hpe/application/automation/tools/run/PcBuilder/config.jelly
+++ b/src/main/resources/com/hpe/application/automation/tools/run/PcBuilder/config.jelly
@@ -162,7 +162,7 @@
             <table style="width:100%" id="trendReportTable">
             <f:radioBlock field="addRunToTrendReport" name="addRunToTrendReport" value="NO_TREND" checked="${instance.pcModel.addRunToTrendReport=='NO_TREND'}" title="Do Not Trend" inline="true">
             </f:radioBlock>
-            <f:radioBlock field="addRunToTrendReport" name="addRunToTrendReport" value="ASSOCIATED" checked="${instance.pcModel.addRunToTrendReport=='ASSOCIATED'}" title="Use trend report associated with the test" inline="true">
+            <f:radioBlock field="addRunToTrendReport" name="addRunToTrendReport" value="ASSOCIATED" checked="${instance.pcModel.addRunToTrendReport=='ASSOCIATED'}" title="Use trend report associated with the test (Performance Center 12.55 or later)" inline="true">
             </f:radioBlock>
             <f:radioBlock field="addRunToTrendReport" name="addRunToTrendReport" value="USE_ID" checked="${instance.pcModel.addRunToTrendReport=='USE_ID'}" title="Add run to trend report with ID" inline="true">
                 <f:entry title="Trend report ID:" field="addRunToTrendReport">


### PR DESCRIPTION
Pc <-> Octane integration

1. A user can now select to automatically find Test Instance ID instead of adding it manually.
2. Support auto trending options




[JENKINS-45155](https://issues.jenkins-ci.org/browse/JENKINS-45155)
[JENKINS-44668](https://issues.jenkins-ci.org/browse/JENKINS-44668)
[JENKINS-44723](https://issues.jenkins-ci.org/browse/JENKINS-44723)