### PR TITLE
Defect: JENKINS-44813 check the job id exists or not before using it …

### DIFF
--- a/src/main/java/com/hpe/application/automation/tools/run/RunFromFileBuilder.java
+++ b/src/main/java/com/hpe/application/automation/tools/run/RunFromFileBuilder.java
@@ -586,7 +586,7 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
 
 		/**
 		 * Gets job id.
-		 * If there is already a job created by jenkins plugin, then return this job id,
+		 * If there is already a job created by jenkins plugin, and exists then return this job id,
 		 * otherwise, create a new temp job and return the new job id.
 		 *
 		 * @param mcUrl         the mc url
@@ -601,7 +601,12 @@ public class RunFromFileBuilder extends Builder implements SimpleBuildStep {
 		@JavaScriptMethod
 		public String getJobId(String mcUrl, String mcUserName, String mcPassword, String proxyAddress, String proxyUserName, String proxyPassword, String previousJobId) {
 			if(null != previousJobId && !previousJobId.isEmpty()){
-				return previousJobId;
+                JSONObject jobJSON = instance.getJobById(mcUrl, mcUserName, mcPassword, proxyAddress, proxyUserName, proxyPassword, previousJobId);
+                if(jobJSON != null && previousJobId.equals(jobJSON.getAsString("id"))){
+                    return previousJobId;
+                }else {
+                    return instance.createTempJob(mcUrl, mcUserName, mcPassword, proxyAddress, proxyUserName, proxyPassword);
+                }
 			}
 			return instance.createTempJob(mcUrl, mcUserName, mcPassword, proxyAddress, proxyUserName, proxyPassword);
 		}


### PR DESCRIPTION
…since multiple mc server configuration
Defect fix for https://issues.jenkins-ci.org/browse/JENKINS-44813, reopened because the multiple mc server configuration might cause the server error by using the wrong job id.

Please Make sure these boxes are checked before submitting your pull request - Thanks ahead!

- [x] Proper pull request title - concise and clear for others.
- [x] Proper pull request short description - clear and concise (as it should appear in the Jira ticket) for other developers and users.
- [x] Proper Jira ticket - Number, Link in pull request description.
- [ ] The PR can is merged on your machine without any conflicts.
- [ ] The PR can is built on your machine without any (new) warnings.
- [ ] The PR passed sanity tests by you / QA / DevTest / Good Samaritain.
- [ ] Add unit tests with new features.
- [ ] If you added any dependency to the POM - Please update @YafimK
