### PR TITLE
Add Content-Length header when post site session

### DIFF
--- a/src/main/java/com/hpe/application/automation/tools/sse/sdk/authenticator/AuthenticationTool.java
+++ b/src/main/java/com/hpe/application/automation/tools/sse/sdk/authenticator/AuthenticationTool.java
@@ -81,11 +81,11 @@ public final class AuthenticationTool {
         Response response =
                 client.httpPost(
                         client.build("rest/site-session"),
-                        null,
+                        new byte[1],    // For some server would require post request has a Content-Length.
                         null,
                         ResourceAccessLevel.PUBLIC);
         if (!response.isOk()) {
-            throw new SSEException("Cannot appned QCSession cookies", response.getFailure());
+            throw new SSEException("Cannot append QCSession cookies", response.getFailure());
         }
     }
 }


### PR DESCRIPTION
1. Site session accept post request but the request contains no content. Some server refuses this and requires a content-length header.
2. Fix the typo.