### PR TITLE
Ocatne 5.2 beta-1 changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
 		<dependency>
 			<artifactId>mqm-rest-client</artifactId>
 			<groupId>com.hpe.adm.octane.ciplugins</groupId>
-			<version>1.4.10</version>
+			<version>1.4.11</version>
 		</dependency>
 
 		<!-- org.jenkins-ci.main -->

--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
 		<dependency>
 			<artifactId>mqm-rest-client</artifactId>
 			<groupId>com.hpe.adm.octane.ciplugins</groupId>
-			<version>1.4.9</version>
+			<version>1.4.10</version>
 		</dependency>
 
 		<!-- org.jenkins-ci.main -->

--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
 		<dependency>
 			<artifactId>mqm-rest-client</artifactId>
 			<groupId>com.hpe.adm.octane.ciplugins</groupId>
-			<version>1.4.7</version>
+			<version>1.4.9</version>
 		</dependency>
 
 		<!-- org.jenkins-ci.main -->

--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
 		<dependency>
 			<artifactId>mqm-rest-client</artifactId>
 			<groupId>com.hpe.adm.octane.ciplugins</groupId>
-			<version>1.4.11</version>
+			<version>1.4.12</version>
 		</dependency>
 
 		<!-- org.jenkins-ci.main -->
@@ -510,12 +510,6 @@
 			<groupId>com.squareup</groupId>
 			<artifactId>tape</artifactId>
 			<version>1.2.3</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.hp.bdi</groupId>
-			<artifactId>bdi-sdk</artifactId>
-			<version>${bdi.version}</version>
 		</dependency>
 
 		<!--Extensibility-->

--- a/src/main/java/com/hpe/application/automation/tools/octane/AbstractResultQueueImpl.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/AbstractResultQueueImpl.java
@@ -31,11 +31,19 @@ import java.io.*;
 
 public abstract class AbstractResultQueueImpl implements ResultQueue {
 
-	private static final int RETRY_COUNT = 3;
+	private final int MAX_RETRIES;
 
 	private FileObjectQueue<QueueItem> queue;
 
 	private QueueItem currentItem;
+
+	public AbstractResultQueueImpl() {
+		this.MAX_RETRIES = 3;
+	}
+
+	public AbstractResultQueueImpl(int maxRetries) {
+		this.MAX_RETRIES = maxRetries;
+	}
 
 	protected void init(File queueFile) throws IOException {
 		queue = new FileObjectQueue<>(queueFile, new JsonConverter());
@@ -53,7 +61,7 @@ public abstract class AbstractResultQueueImpl implements ResultQueue {
 	public synchronized boolean failed() {
 		if (currentItem != null) {
 			boolean retry;
-			if (++currentItem.failCount <= RETRY_COUNT) {
+			if (++currentItem.failCount <= MAX_RETRIES) {
 				queue.add(currentItem);
 				retry = true;
 			} else {

--- a/src/main/java/com/hpe/application/automation/tools/octane/CIJenkinsServicesImpl.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/CIJenkinsServicesImpl.java
@@ -16,18 +16,6 @@
 
 package com.hpe.application.automation.tools.octane;
 
-import com.hpe.application.automation.tools.model.OctaneServerSettingsModel;
-import com.hpe.application.automation.tools.octane.configuration.ConfigurationService;
-import com.hpe.application.automation.tools.octane.configuration.ServerConfiguration;
-import com.hpe.application.automation.tools.octane.executor.ExecutorConnectivityService;
-import com.hpe.application.automation.tools.octane.executor.TestExecutionJobCreatorService;
-import com.hpe.application.automation.tools.octane.executor.UftJobCleaner;
-import com.hpe.application.automation.tools.octane.model.ModelFactory;
-import com.hpe.application.automation.tools.octane.model.processors.parameters.ParameterProcessors;
-import com.hpe.application.automation.tools.octane.model.processors.projects.AbstractProjectProcessor;
-import com.hpe.application.automation.tools.octane.model.processors.projects.JobProcessorFactory;
-import com.hpe.application.automation.tools.octane.model.processors.scm.SCMProcessor;
-import com.hpe.application.automation.tools.octane.model.processors.scm.SCMProcessors;
 import com.hp.octane.integrations.dto.DTOFactory;
 import com.hp.octane.integrations.dto.configuration.CIProxyConfiguration;
 import com.hp.octane.integrations.dto.configuration.OctaneConfiguration;
@@ -49,6 +37,18 @@ import com.hp.octane.integrations.dto.tests.TestsResult;
 import com.hp.octane.integrations.exceptions.ConfigurationException;
 import com.hp.octane.integrations.exceptions.PermissionException;
 import com.hp.octane.integrations.spi.CIPluginServicesBase;
+import com.hpe.application.automation.tools.model.OctaneServerSettingsModel;
+import com.hpe.application.automation.tools.octane.configuration.ConfigurationService;
+import com.hpe.application.automation.tools.octane.configuration.ServerConfiguration;
+import com.hpe.application.automation.tools.octane.executor.ExecutorConnectivityService;
+import com.hpe.application.automation.tools.octane.executor.TestExecutionJobCreatorService;
+import com.hpe.application.automation.tools.octane.executor.UftJobCleaner;
+import com.hpe.application.automation.tools.octane.model.ModelFactory;
+import com.hpe.application.automation.tools.octane.model.processors.parameters.ParameterProcessors;
+import com.hpe.application.automation.tools.octane.model.processors.projects.AbstractProjectProcessor;
+import com.hpe.application.automation.tools.octane.model.processors.projects.JobProcessorFactory;
+import com.hpe.application.automation.tools.octane.model.processors.scm.SCMProcessor;
+import com.hpe.application.automation.tools.octane.model.processors.scm.SCMProcessors;
 import hudson.ProxyConfiguration;
 import hudson.model.*;
 import hudson.security.ACL;
@@ -541,27 +541,53 @@ public class CIJenkinsServicesImpl extends CIPluginServicesBase {
 
     @Override
     public void runTestDiscovery(DiscoveryInfo discoveryInfo) {
-        TestExecutionJobCreatorService.runTestDiscovery(discoveryInfo);
+        SecurityContext securityContext = startImpersonation();
+        try {
+            TestExecutionJobCreatorService.runTestDiscovery(discoveryInfo);
+        } finally {
+            stopImpersonation(securityContext);
+        }
     }
 
     @Override
     public void runTestSuiteExecution(TestSuiteExecutionInfo suiteExecutionInfo) {
-        TestExecutionJobCreatorService.runTestSuiteExecution(suiteExecutionInfo);
+        SecurityContext securityContext = startImpersonation();
+        try {
+            TestExecutionJobCreatorService.runTestSuiteExecution(suiteExecutionInfo);
+        } finally {
+            stopImpersonation(securityContext);
+        }
     }
 
     @Override
     public OctaneResponse checkRepositoryConnectivity(TestConnectivityInfo testConnectivityInfo) {
-        return ExecutorConnectivityService.checkRepositoryConnectivity(testConnectivityInfo);
+        SecurityContext securityContext = startImpersonation();
+        try {
+            return ExecutorConnectivityService.checkRepositoryConnectivity(testConnectivityInfo);
+        } finally {
+            stopImpersonation(securityContext);
+        }
     }
 
     @Override
     public void deleteExecutor(String id) {
-        UftJobCleaner.deleteExecutor(id);
+        SecurityContext securityContext = startImpersonation();
+        try {
+            UftJobCleaner.deleteExecutor(id);
+        } finally {
+            stopImpersonation(securityContext);
+        }
+
     }
 
     @Override
     public OctaneResponse upsertCredentials(CredentialsInfo credentialsInfo) {
-        return ExecutorConnectivityService.upsertRepositoryCredentials(credentialsInfo);
+        SecurityContext securityContext = startImpersonation();
+        try {
+            return ExecutorConnectivityService.upsertRepositoryCredentials(credentialsInfo);
+        } finally {
+            stopImpersonation(securityContext);
+        }
     }
 
 }

--- a/src/main/java/com/hpe/application/automation/tools/octane/buildLogs/LogDispatcher.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/buildLogs/LogDispatcher.java
@@ -16,25 +16,16 @@
 
 package com.hpe.application.automation.tools.octane.buildLogs;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.Longs;
 import com.google.inject.Inject;
-import com.hp.indi.bdi.client.BdiClientV2;
 import com.hp.mqm.client.MqmRestClient;
+import com.hp.mqm.client.exception.RequestErrorException;
 import com.hpe.application.automation.tools.octane.ResultQueue;
-import com.hpe.application.automation.tools.octane.client.JenkinsMqmRestClientFactory;
-import com.hpe.application.automation.tools.octane.client.JenkinsMqmRestClientFactoryImpl;
-import com.hpe.application.automation.tools.octane.client.RetryModel;
-import com.hpe.application.automation.tools.octane.configuration.BdiConfiguration;
+import com.hpe.application.automation.tools.octane.client.*;
 import com.hpe.application.automation.tools.octane.configuration.ConfigurationService;
 import com.hpe.application.automation.tools.octane.configuration.ServerConfiguration;
 import com.hpe.application.automation.tools.octane.tests.AbstractSafeLoggingAsyncPeriodWork;
-import com.hp.indi.bdi.client.BdiClient;
-import com.hp.indi.bdi.client.BdiClientFactory;
-import com.hp.indi.bdi.client.BdiProxyConfiguration;
 import hudson.Extension;
-import hudson.ProxyConfiguration;
 import hudson.console.PlainTextConsoleOutputStream;
 import hudson.model.Job;
 import hudson.model.Run;
@@ -46,11 +37,13 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.Long.parseLong;
 
 /**
  * Created by benmeior on 11/20/2016
@@ -60,51 +53,29 @@ import java.nio.file.Files;
 @Extension
 public class LogDispatcher extends AbstractSafeLoggingAsyncPeriodWork {
 	private static final Logger logger = LogManager.getLogger(LogDispatcher.class);
-	private static final ObjectMapper objectMapper = new ObjectMapper();
+	private static final ExecutorService logDispatcherExecutors = Executors.newFixedThreadPool(20, new NamedThreadFactory(LogDispatcher.class.getSimpleName()));
 
 	private static final String OCTANE_LOG_FILE_NAME = "octane_log";
-	private static final String BDI_PRODUCT = "octane";
-	private static final String CONSOLE_LOG_DATA_TYPE = "consolelog";
+	private static final int MAX_RETRIES = 6;
 
-	@Inject
 	private RetryModel retryModel;
-	@Inject
-	private BdiConfigurationFetcher bdiConfigurationFetcher;
-
 	private JenkinsMqmRestClientFactory clientFactory;
-	private ResultQueue logsQueue;
-	private BdiClientV2 bdiClient;
-	private BdiClient deprecatedClient;
-	private ProxyConfiguration proxyConfiguration;
+	private final ResultQueue logsQueue;
 
-	public LogDispatcher() {
-		super("BDI log dispatcher");
+	public LogDispatcher() throws IOException {
+		super("Octane log dispatcher");
+		logsQueue = new LogsResultQueue(MAX_RETRIES);
 	}
 
-	public void initClient() {
-		closeClient();
-
-		Jenkins jenkins = Jenkins.getInstance();
-		if (jenkins == null) {
-			logger.error("Jenkins container was not properly initialized");
-			return;
+	private long[] getQuietPeriodsInMinutes(double retries) {
+		double base = 2;
+		double exponent = 0;
+		List<Long> quietPeriods = new ArrayList<>();
+		while (exponent <= retries) {
+			quietPeriods.add(TimeUnit2.MINUTES.toMillis((long) Math.pow(base, exponent)));
+			exponent++;
 		}
-		BdiConfiguration bdiConfiguration = bdiConfigurationFetcher.obtain();
-		if (bdiConfiguration == null || !bdiConfiguration.isFullyConfigured()) {
-			logger.debug("BDI is not configured in Octane");
-			return;
-		}
-		System.setProperty("bdi_use_ssl", String.valueOf(bdiConfiguration.isSsl() || "443".equals(bdiConfiguration.getPort())));
-		this.proxyConfiguration = jenkins.proxy;
-		if (proxyConfiguration == null) {
-			bdiClient = BdiClientFactory.getBdiClientV2(bdiConfiguration.getHost(), bdiConfiguration.getPort());
-			deprecatedClient = BdiClientFactory.getBdiClient(bdiConfiguration.getHost(), bdiConfiguration.getPort());
-		} else {
-			BdiProxyConfiguration bdiProxyConfiguration =
-					new BdiProxyConfiguration(proxyConfiguration.name, proxyConfiguration.port, proxyConfiguration.getUserName(), proxyConfiguration.getPassword());
-			bdiClient = BdiClientFactory.getBdiClientV2(bdiConfiguration.getHost(), bdiConfiguration.getPort(), bdiProxyConfiguration);
-			deprecatedClient = BdiClientFactory.getBdiClient(bdiConfiguration.getHost(), bdiConfiguration.getPort(), bdiProxyConfiguration);
-		}
+		return Longs.toArray(quietPeriods);
 	}
 
 	@Override
@@ -112,80 +83,114 @@ public class LogDispatcher extends AbstractSafeLoggingAsyncPeriodWork {
 		if (logsQueue.peekFirst() == null) {
 			return;
 		}
-		if (retryModel.isQuietPeriod()) {
-			logger.info("There are pending logs, but we are in quiet period");
+
+		MqmRestClient mqmRestClient = initMqmRestClient();
+		if (mqmRestClient == null) {
+			logger.warn("There are pending build logs, but MQM server location is not specified, build logs can't be submitted");
+			logsQueue.remove();
 			return;
 		}
 
-		//  verify configuration
-		Jenkins jenkins = Jenkins.getInstance();
-		if (jenkins == null) {
-			logger.error("Jenkins container was not properly initialized");
-			return;
-		}
-		BdiConfiguration bdiConfiguration = bdiConfigurationFetcher.obtain();
-		if (bdiConfiguration == null || !bdiConfiguration.isFullyConfigured()) {
-			logger.error("Could not send logs. BDI is not configured");
-			logsQueue.clear();
-			closeClient();
-			return;
-		} else if (!bdiConfiguration.isAccessTokenFlavor() && !isPemFilePropertyInit()) {
-			return;
-		}
-
-		//  proceed to process queue item
-		manageLogsQueue(jenkins, bdiConfiguration);
-	}
-
-	private void manageLogsQueue(Jenkins jenkins, BdiConfiguration bdiConfiguration) {
 		ResultQueue.QueueItem item;
-		File logFile = null;
-		Run build = null;
+
 		while ((item = logsQueue.peekFirst()) != null) {
-			try {
-				build = getBuildFromQueueItem(jenkins, item);
-				if (build == null) {
-					logsQueue.remove();
-					continue;
-				}
 
-				logFile = getOctaneLogFile(build);
+			if (retryModel.isQuietPeriod()) {
+				logger.debug("There are pending logs, but we are in quiet period");
+				return;
+			}
 
-				if (bdiClient == null || deprecatedClient == null || proxyConfiguration != jenkins.proxy) {
-					initClient();
-				}
-
-				if (bdiConfiguration.isAccessTokenFlavor()) {
-					bdiClient.post(CONSOLE_LOG_DATA_TYPE, BDI_PRODUCT, bdiConfiguration.getTenantId(), item.getWorkspace(), buildDataId(build), logFile, retrieveAccessToken());
-				} else {
-					deprecatedClient.post(CONSOLE_LOG_DATA_TYPE, BDI_PRODUCT, bdiConfiguration.getTenantId(), item.getWorkspace(), buildDataId(build), logFile);
-				}
-
-				logger.info(String.format("Successfully sent log of build [%s#%s]", item.getProjectName(), item.getBuildNumber()));
-
+			Run build = getBuildFromQueueItem(item);
+			if (build == null) {
+				logger.warn("Build and/or Project [" + item.getProjectName() + "#" + item.getBuildNumber() + "] no longer exists, pending build logs can't be submitted");
 				logsQueue.remove();
-				Files.deleteIfExists(logFile.toPath());
-			} catch (Exception e) {
-				logger.error(String.format("Could not send log of build [%s#%s] to bdi.", item.getProjectName(), item.getBuildNumber()), e);
-				if (!logsQueue.failed()) {
-					logger.warn("Maximum number of attempts reached, operation will not be re-attempted for this build");
-					if (logFile != null) {
-						try {
-							Files.deleteIfExists(logFile.toPath());
-						} catch (IOException e1) {
-							String errorMsg = "Could not delete Octane log file";
-							if (build != null) {
-								errorMsg = String.format("%s of %s#%s", errorMsg, build.getParent().getName(), String.valueOf(build.getNumber()));
-							}
-							logger.error(errorMsg);
+				continue;
+			}
+
+			try {
+				if (item.getWorkspace() == null) {
+					//
+					//  initial queue item flow - no workspaces, works with workspaces retrieval and loop ever each of them
+					//
+					List<String> workspaces = mqmRestClient.getJobWorkspaceId(ConfigurationService.getModel().getIdentity(), build.getParent().getName());
+					if (workspaces.isEmpty()) {
+						logger.info(String.format("Job '%s' is not part of an Octane pipeline in any workspace, so its log will not be sent.", build.getParent().getName()));
+					} else {
+						CountDownLatch latch = new CountDownLatch(workspaces.size());
+
+						for (String workspaceId : workspaces) {
+							logDispatcherExecutors.execute(new SendLogsExecutor(
+									mqmRestClient,
+									build,
+									item,
+									workspaceId,
+									logsQueue,
+									latch
+							));
 						}
+
+						latch.await(20, TimeUnit.MINUTES);
+					}
+					logsQueue.remove();
+				} else {
+					//
+					//  secondary queue item flow - workspace is known, we are in retry flow
+					//
+					try {
+						OctaneLog octaneLog = getOctaneLogFile(build);
+						boolean status = mqmRestClient.postLogs(
+								parseLong(item.getWorkspace()),
+								ConfigurationService.getModel().getIdentity(),
+								build.getParent().getName(),
+								String.valueOf(build.getNumber()),
+								octaneLog.getLogStream(),
+								octaneLog.getFileLength());
+						if (status) {
+							logger.info("Successfully sent logs of " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + item.getWorkspace());
+							logsQueue.remove();
+						} else {
+							logger.error("failed to send log for build " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + item.getWorkspace());
+							reAttempt(item.getProjectName(), item.getBuildNumber());
+						}
+					} catch (RequestErrorException ree) {
+						logger.error("failed to send log for build " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + item.getWorkspace(), ree);
+						reAttempt(item.getProjectName(), item.getBuildNumber());
+					} catch (Exception e) {
+						logger.error("fatally failed to send log for build " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + item.getWorkspace() + ", will not retry this one", e);
+						retryModel.success();
+						logsQueue.remove();
 					}
 				}
+			} catch (Exception e) {
+				logger.error("fatally failed to fetch relevant workspaces OR to send log for build " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + item.getWorkspace() + ", will not retry this one", e);
 			}
 		}
 	}
 
-	private File getOctaneLogFile(Run build) throws IOException {
+	private void reAttempt(String projectName, int buildNumber) {
+		if (!logsQueue.failed()) {
+			logger.warn("maximum number of attempts reached, operation will not be re-attempted for build "+ projectName + " #" + buildNumber);
+			retryModel.success();
+		} else {
+			logger.info("There are pending logs, but we are in quiet period");
+			retryModel.failure();
+		}
+	}
+
+	private MqmRestClient initMqmRestClient() {
+		MqmRestClient result = null;
+		ServerConfiguration configuration = ConfigurationService.getServerConfiguration();
+		if (configuration.isValid()) {
+			result = clientFactory.obtain(
+					configuration.location,
+					configuration.sharedSpace,
+					configuration.username,
+					configuration.password);
+		}
+		return result;
+	}
+
+	private OctaneLog getOctaneLogFile(Run build) throws IOException {
 		String octaneLogFilePath = build.getLogFile().getParent() + File.separator + OCTANE_LOG_FILE_NAME;
 		File logFile = new File(octaneLogFilePath);
 		if (!logFile.exists()) {
@@ -196,70 +201,16 @@ public class LogDispatcher extends AbstractSafeLoggingAsyncPeriodWork {
 				out.flush();
 			}
 		}
-		return logFile;
+		return new OctaneLog(logFile);
 	}
 
-	private MqmRestClient createMqmRestClient() {
-		ServerConfiguration configuration = ConfigurationService.getServerConfiguration();
-		if (configuration.isValid()) {
-			return clientFactory.obtain(
-					configuration.location,
-					configuration.sharedSpace,
-					configuration.username,
-					configuration.password);
-		}
-		return null;
-	}
-
-	private String retrieveAccessToken() throws IOException {
-		String result;
-		MqmRestClient mqmRestClient = createMqmRestClient();
-		if (mqmRestClient != null) {
-			BdiTokenData bdiTokenData = objectMapper.readValue(mqmRestClient.getBdiTokenData(), BdiTokenData.class);
-			if (bdiTokenData.token != null) {
-				result = bdiTokenData.token;
-			} else {
-				throw new IllegalStateException("invalid [NULL] access token received from Octane");
-			}
-		} else {
-			throw new IllegalStateException("failed to create RestClient to retrieve access token from Octane");
+	private Run getBuildFromQueueItem(ResultQueue.QueueItem item) {
+		Run result = null;
+		Job project = (Job) Jenkins.getInstance().getItemByFullName(item.getProjectName());
+		if (project != null) {
+			result = project.getBuildByNumber(item.getBuildNumber());
 		}
 		return result;
-	}
-
-	private void closeClient() {
-		try {
-			if (bdiClient != null) bdiClient.close();
-			if (deprecatedClient != null) deprecatedClient.close();
-		} catch (Exception e) {
-			logger.error("Failed to close BDI client");
-		} finally {
-			bdiClient = null;
-			deprecatedClient = null;
-		}
-	}
-
-	private Run getBuildFromQueueItem(Jenkins jenkins, ResultQueue.QueueItem item) {
-		Job project = (Job) jenkins.getItemByFullName(item.getProjectName());
-		if (project == null) {
-			logger.warn("Project [" + item.getProjectName() + "] no longer exists, pending logs can't be submitted");
-			return null;
-		}
-
-		Run build = project.getBuildByNumber(item.getBuildNumber());
-		if (build == null) {
-			logger.warn("Build [" + item.getProjectName() + "#" + item.getBuildNumber() + "] no longer exists, pending logs can't be submitted");
-			return null;
-		}
-		return build;
-	}
-
-	private String buildDataId(Run build) {
-		String ciServerId = ConfigurationService.getModel().getIdentity();
-		String ciBuildId = String.valueOf(build.getNumber());
-		String jobName = build.getParent().getName();
-
-		return String.format("%s-%s-%s", ciServerId, ciBuildId, jobName.replaceAll(" ", ""));
 	}
 
 	@Override
@@ -271,8 +222,13 @@ public class LogDispatcher extends AbstractSafeLoggingAsyncPeriodWork {
 		return TimeUnit2.SECONDS.toMillis(10);
 	}
 
-	void enqueueLog(String projectName, int buildNumber, String workspace) {
-		logsQueue.add(projectName, buildNumber, workspace);
+	public void enqueueLog(String projectName, int buildNumber) {
+		logsQueue.add(projectName, buildNumber, null);
+	}
+
+	@Inject
+	public void setEventPublisher(JenkinsInsightEventPublisher eventPublisher) {
+		this.retryModel = new RetryModel(eventPublisher, getQuietPeriodsInMinutes(MAX_RETRIES));
 	}
 
 	@Inject
@@ -280,18 +236,70 @@ public class LogDispatcher extends AbstractSafeLoggingAsyncPeriodWork {
 		this.clientFactory = clientFactory;
 	}
 
-	@Inject
-	public void setLogResultQueue(LogAbstractResultQueue queue) {
-		this.logsQueue = queue;
+	private static final class NamedThreadFactory implements ThreadFactory {
+
+		private AtomicInteger threadNumber = new AtomicInteger(1);
+		private final String namePrefix;
+
+		private NamedThreadFactory(String namePrefix) {
+			this.namePrefix = namePrefix;
+		}
+
+		public Thread newThread(Runnable runnable) {
+			Thread result = new Thread(runnable, this.namePrefix + " thread-" + threadNumber.getAndIncrement());
+			result.setDaemon(true);
+			return result;
+		}
 	}
 
-	@JsonIgnoreProperties(ignoreUnknown = true)
-	@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-	private static final class BdiTokenData {
-		private String token;
+	private final class SendLogsExecutor implements Runnable {
+		private final MqmRestClient mqmRestClient;
+		private final Run build;
+		private final ResultQueue.QueueItem item;
+		private final String workspaceId;
+		private final ResultQueue logsQueue;
+		private final CountDownLatch latch;
+
+		private SendLogsExecutor(
+				MqmRestClient mqmRestClient,
+				Run build,
+				ResultQueue.QueueItem item,
+				String workspaceId,
+				ResultQueue logsQueue,
+				CountDownLatch latch) {
+			this.mqmRestClient = mqmRestClient;
+			this.build = build;
+			this.item = item;
+			this.workspaceId = workspaceId;
+			this.logsQueue = logsQueue;
+			this.latch = latch;
+		}
+
+		@Override
+		public void run() {
+			try {
+				OctaneLog octaneLog = getOctaneLogFile(build);
+				boolean status = mqmRestClient.postLogs(
+						parseLong(workspaceId),
+						ConfigurationService.getModel().getIdentity(),
+						build.getParent().getName(),
+						String.valueOf(build.getNumber()),
+						octaneLog.getLogStream(),
+						octaneLog.getFileLength());
+				if (status) {
+					logger.info("Successfully sent logs of " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + workspaceId);
+				} else {
+					logger.debug("failed to send log for build " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + workspaceId);
+					logsQueue.add(item.getProjectName(), item.getBuildNumber(), workspaceId);
+				}
+			} catch (RequestErrorException ree) {
+				logger.debug("failed to send log for build " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + workspaceId, ree);
+				logsQueue.add(item.getProjectName(), item.getBuildNumber(), workspaceId);
+			} catch (Exception e) {
+				logger.error("fatally failed to send log for build " + item.getProjectName() + " #" + item.getBuildNumber() + " to workspace " + workspaceId + ", will not retry this one", e);
+			}
+			latch.countDown();
+		}
 	}
 
-	private boolean isPemFilePropertyInit() {
-		return System.getProperty("pem_file") != null && !System.getProperty("pem_file").isEmpty();
-	}
 }

--- a/src/main/java/com/hpe/application/automation/tools/octane/buildLogs/LogsResultQueue.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/buildLogs/LogsResultQueue.java
@@ -28,9 +28,10 @@ import java.io.IOException;
  * Queue, based on persisted, file-object backed by base queue, serving the Logs dispatching logic to BDI when relevant
  */
 
-public class LogAbstractResultQueue extends AbstractResultQueueImpl {
+class LogsResultQueue extends AbstractResultQueueImpl {
 
-	public LogAbstractResultQueue() throws IOException {
+	LogsResultQueue(int maxRetries) throws IOException {
+		super(maxRetries);
 		Jenkins jenkinsContainer = Jenkins.getInstance();
 		if (jenkinsContainer != null) {
 			File queueFile = new File(jenkinsContainer.getRootDir(), "octane-log-result-queue.dat");

--- a/src/main/java/com/hpe/application/automation/tools/octane/buildLogs/OctaneLog.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/buildLogs/OctaneLog.java
@@ -1,0 +1,27 @@
+package com.hpe.application.automation.tools.octane.buildLogs;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+
+class OctaneLog {
+
+	final private Long fileLength;
+
+	final private InputStream logStream;
+
+	OctaneLog(File logFile) throws FileNotFoundException {
+		this.fileLength = logFile.length();
+		this.logStream = new FileInputStream(logFile);
+	}
+
+	public Long getFileLength() {
+		return this.fileLength;
+	}
+
+	public InputStream getLogStream() {
+		return this.logStream;
+	}
+
+}

--- a/src/main/java/com/hpe/application/automation/tools/octane/buildLogs/RunListenerForLogs.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/buildLogs/RunListenerForLogs.java
@@ -17,12 +17,7 @@
 package com.hpe.application.automation.tools.octane.buildLogs;
 
 import com.google.inject.Inject;
-import com.hp.mqm.client.MqmRestClient;
-import com.hpe.application.automation.tools.octane.client.JenkinsMqmRestClientFactory;
-import com.hpe.application.automation.tools.octane.client.JenkinsMqmRestClientFactoryImpl;
-import com.hpe.application.automation.tools.octane.configuration.BdiConfiguration;
 import com.hpe.application.automation.tools.octane.configuration.ConfigurationService;
-import com.hpe.application.automation.tools.octane.configuration.ServerConfiguration;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
@@ -32,7 +27,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
-import java.util.List;
 
 /**
  * Created by benmeior on 11/16/2016
@@ -43,63 +37,22 @@ import java.util.List;
 public class RunListenerForLogs extends RunListener<Run> {
 	private static Logger logger = LogManager.getLogger(RunListenerForLogs.class);
 
-	private JenkinsMqmRestClientFactory clientFactory;
-
 	@Inject
 	private LogDispatcher logDispatcher;
-	@Inject
-	private BdiConfigurationFetcher bdiConfigurationFetcher;
+
 
 	//  [YG] TODO: move workspace resolving logic to the async processor off the main thread
 	@Override
 	public void onCompleted(Run r, @Nonnull TaskListener listener) {
-		BdiConfiguration bdiConfiguration = bdiConfigurationFetcher.obtain();
-		if (bdiConfiguration == null || !bdiConfiguration.isFullyConfigured()) {
-			logger.debug("BDI is not configured in Octane");
-			return;
+
+		if (r instanceof AbstractBuild && ConfigurationService.getServerConfiguration().isValid()) {
+			AbstractBuild build = (AbstractBuild) r;
+			logger.info(String.format("Enqueued job [%s#%d]", build.getParent().getName(), build.getNumber()));
+			logDispatcher.enqueueLog(build.getProject().getName(), build.getNumber());
+		} else {
+			logger.warn("Octane configuration is not valid");
 		}
 
-		if (!(r instanceof AbstractBuild)) {
-			return;
-		}
-
-		AbstractBuild build = (AbstractBuild) r;
-
-		try {
-			MqmRestClient mqmRestClient = createMqmRestClient();
-			if (mqmRestClient == null) {
-				logger.warn("Octane configuration is not valid");
-				return;
-			}
-
-			List<String> workspaces = mqmRestClient.getJobWorkspaceId(ConfigurationService.getModel().getIdentity(), build.getParent().getName());
-			if (workspaces.isEmpty()) {
-				logger.info(String.format("Job '%s' is not part of an Octane pipeline in any workspace, so its log will not be sent.", build.getParent().getName()));
-			} else {
-				for (String workspace : workspaces) {
-					logger.info(String.format("Enqueued job [%s#%d] of workspace %s", build.getParent().getName(), build.getNumber(), workspace));
-					logDispatcher.enqueueLog(build.getProject().getName(), build.getNumber(), workspace);
-				}
-			}
-		} catch (Exception e) {
-			logger.error(String.format("Could not enqueue log for job %s", build.getParent().getName()));
-		}
 	}
 
-	private MqmRestClient createMqmRestClient() {
-		ServerConfiguration configuration = ConfigurationService.getServerConfiguration();
-		if (configuration.isValid()) {
-			return clientFactory.obtain(
-					configuration.location,
-					configuration.sharedSpace,
-					configuration.username,
-					configuration.password);
-		}
-		return null;
-	}
-
-	@Inject
-	public void setMqmRestClientFactory(JenkinsMqmRestClientFactoryImpl clientFactory) {
-		this.clientFactory = clientFactory;
-	}
 }

--- a/src/main/java/com/hpe/application/automation/tools/octane/client/RetryModel.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/client/RetryModel.java
@@ -25,7 +25,7 @@ import hudson.util.TimeUnit2;
 @Extension
 public class RetryModel implements ConfigurationListener {
 
-    private static final long[] QUIET_PERIOD = { // TODO: janotav: verify against our Saas policy
+    private long[] QUIET_PERIOD = {
             TimeUnit2.MINUTES.toMillis(1),
             TimeUnit2.MINUTES.toMillis(10),
             TimeUnit2.MINUTES.toMillis(60)
@@ -42,6 +42,11 @@ public class RetryModel implements ConfigurationListener {
         doSuccess();
     }
 
+    public RetryModel(EventPublisher eventPublisher, long... quietPeriods) {
+        doSuccess();
+        this.eventPublisher = eventPublisher;
+        QUIET_PERIOD = quietPeriods;
+    }
 
     public RetryModel(EventPublisher eventPublisher) {
         this();

--- a/src/main/java/com/hpe/application/automation/tools/octane/model/processors/parameters/ParameterProcessors.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/model/processors/parameters/ParameterProcessors.java
@@ -31,6 +31,8 @@ import java.util.Map;
 
 /**
  * Created by gullery on 26/03/2015.
+ *
+ * This class incorporates helper methods for handling Jenkins job parameters.
  */
 
 public enum ParameterProcessors {
@@ -58,7 +60,7 @@ public enum ParameterProcessors {
 		AbstractParametersProcessor processor;
 		if (job.getProperty(ParametersDefinitionProperty.class) != null) {
 			paramDefinitions = ((ParametersDefinitionProperty) job.getProperty(ParametersDefinitionProperty.class)).getParameterDefinitions();
-			for (int i = 0; i < paramDefinitions.size(); i++) {
+			for (int i = 0; paramDefinitions != null && i < paramDefinitions.size(); i++) {
 				pd = paramDefinitions.get(i);
 				className = pd.getClass().getName();
 				processor = getAppropriate(className);

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/TestDispatcher.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/TestDispatcher.java
@@ -205,7 +205,7 @@ public class TestDispatcher extends AbstractSafeLoggingAsyncPeriodWork {
 	}
 
 	@Inject
-	public void setTestResultQueue(TestAbstractResultQueue queue) {
+	public void setTestResultQueue(TestsResultQueue queue) {
 		this.queue = queue;
 	}
 

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/TestListener.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/TestListener.java
@@ -129,7 +129,7 @@ public class TestListener {
 	}
 
 	@Inject
-	public void setTestResultQueue(TestAbstractResultQueue queue) {
+	public void setTestResultQueue(TestsResultQueue queue) {
 		this.queue = queue;
 	}
 

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/TestsResultQueue.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/TestsResultQueue.java
@@ -26,9 +26,9 @@ import java.io.IOException;
 
 @Extension
 @SuppressWarnings("squid:S2259")
-public class TestAbstractResultQueue extends AbstractResultQueueImpl {
+public class TestsResultQueue extends AbstractResultQueueImpl {
 
-    public TestAbstractResultQueue() throws IOException {
+    public TestsResultQueue() throws IOException {
         Jenkins instance =Jenkins.getInstance();
         if(instance==null){
             Assert.isNull(instance);
@@ -40,7 +40,7 @@ public class TestAbstractResultQueue extends AbstractResultQueueImpl {
     /*
      * To be used in tests only.
      */
-    TestAbstractResultQueue(File queueFile) throws IOException {
+    TestsResultQueue(File queueFile) throws IOException {
         init(queueFile);
     }
 }

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/impl/ObjectStreamIterator.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/impl/ObjectStreamIterator.java
@@ -48,6 +48,7 @@ public class ObjectStreamIterator<E> implements Iterator<E> {
 			next = (E) ois.readObject();
 			return true;
 		} catch (Exception e) {
+			logger.error("Failed to read the next item", e);
 			ois.close();
 			return false;
 		}

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/impl/ObjectStreamIterator.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/impl/ObjectStreamIterator.java
@@ -48,7 +48,6 @@ public class ObjectStreamIterator<E> implements Iterator<E> {
 			next = (E) ois.readObject();
 			return true;
 		} catch (Exception e) {
-			logger.error("Failed to read the next item", e);
 			ois.close();
 			return false;
 		}

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitExtension.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitExtension.java
@@ -41,10 +41,7 @@ import org.jenkinsci.remoting.RoleChecker;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.*;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Converter of Jenkins test report to ALM Octane test report format(junitResult.xml->mqmTests.xml)
@@ -124,7 +121,7 @@ public class JUnitExtension extends MqmTestsExtension {
 		} else if (isLoadRunnerProject) {
 			detectedFields = new ResultFields(null, LOAD_RUNNER, null);
 		} else if (hpRunnerType.equals(HPRunnerType.PerformanceCenter)) {
-			detectedFields = new ResultFields(null, null/*PERFORMANCE_CENTER_RUNNER*/, null, PERFORMANCE_TEST_TYPE);
+			detectedFields = new ResultFields(null, PERFORMANCE_CENTER_RUNNER, null, PERFORMANCE_TEST_TYPE);
 		} else {
 			detectedFields = resultFieldsDetectionService.getDetectedFields(build);
 		}
@@ -155,12 +152,16 @@ public class JUnitExtension extends MqmTestsExtension {
 		private final String buildId;
 		private final String jenkinsRootUrl;
 		private final HPRunnerType hpRunnerType;
-		private boolean isUFTProject = false;
 		private FilePath filePath;
 		private List<ModuleDetection> moduleDetection;
 		private long buildStarted;
 		private FilePath workspace;
 		private boolean stripPackageAndClass;
+
+		//this class is run on master and JUnitXmlIterator is runnning on slave.
+		//this object pass some master2slave data
+		private Object additionalContext;
+		private String buildRootDir;
 
 		public GetJUnitTestResults( Run<?, ?> build, List<FilePath> reports, boolean stripPackageAndClass, HPRunnerType hpRunnerType, String jenkinsRootUrl) throws IOException, InterruptedException {
 			this.reports = reports;
@@ -170,13 +171,34 @@ public class JUnitExtension extends MqmTestsExtension {
 			this.stripPackageAndClass = stripPackageAndClass;
 			this.hpRunnerType = hpRunnerType;
 			this.jenkinsRootUrl = jenkinsRootUrl;
+			this.buildRootDir = build.getRootDir().getCanonicalPath();
+
+
 			//AbstractProject project = (AbstractProject)build.getParent();/*build.getProject()*/;
 			this.jobName =build.getParent().getName();// project.getName();
-			this.buildId =BuildHandlerUtils.getBuildId(build);///*build.getProject()*/((AbstractProject)build.getParent()).getBuilds().getLastBuild().getId();
+			this.buildId = BuildHandlerUtils.getBuildId(build);///*build.getProject()*/((AbstractProject)build.getParent()).getBuilds().getLastBuild().getId();
 			moduleDetection =Arrays.asList(
 					new MavenBuilderModuleDetection(build),
 					new MavenSetModuleDetection(build),
 					new ModuleDetection.Default());
+
+
+			if(HPRunnerType.UFT.equals(hpRunnerType)){
+
+				//extract folder names for created tests
+				String reportFolder = buildRootDir + "/archive/UFTReport";
+				Set<String> testFolderNames = new HashSet<>();
+				File reportFolderFile = new File(reportFolder);
+				if (reportFolderFile.exists()) {
+					File[] children = reportFolderFile.listFiles();
+					if (children != null) {
+						for (File child : children) {
+							testFolderNames.add(child.getName());
+						}
+					}
+				}
+				additionalContext = testFolderNames;
+			}
 		}
 
 		@Override
@@ -187,7 +209,7 @@ public class JUnitExtension extends MqmTestsExtension {
 
 			try {
 				for (FilePath report : reports) {
-					JUnitXmlIterator iterator = new JUnitXmlIterator(report.read(), moduleDetection, workspace, jobName, buildId, buildStarted, stripPackageAndClass, hpRunnerType, jenkinsRootUrl);
+					JUnitXmlIterator iterator = new JUnitXmlIterator(report.read(), moduleDetection, workspace, jobName, buildId, buildStarted, stripPackageAndClass, hpRunnerType, jenkinsRootUrl, additionalContext);
 					while (iterator.hasNext()) {
 						oos.writeObject(iterator.next());
 					}

--- a/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitExtension.java
+++ b/src/main/java/com/hpe/application/automation/tools/octane/tests/junit/JUnitExtension.java
@@ -52,7 +52,7 @@ public class JUnitExtension extends MqmTestsExtension {
 
 	public static final String STORM_RUNNER = "StormRunner";
 	public static final String LOAD_RUNNER = "LoadRunner";
-	public static final String PERFORMANCE_CENTER_RUNNER = "Performance Center1";
+	public static final String PERFORMANCE_CENTER_RUNNER = "Performance Center";
 	public static final String PERFORMANCE_TEST_TYPE = "Performance";
 
 	private static final String JUNIT_RESULT_XML = "junitResult.xml"; // NON-NLS

--- a/src/main/java/com/hpe/application/automation/tools/sse/result/JUnitParser.java
+++ b/src/main/java/com/hpe/application/automation/tools/sse/result/JUnitParser.java
@@ -15,15 +15,18 @@ import com.hpe.application.automation.tools.sse.result.model.junit.Testsuite;
 import com.hpe.application.automation.tools.sse.result.model.junit.Testsuites;
 
 public class JUnitParser {
+
+    private String entityId;
     
     public Testsuites toModel(
             List<Map<String, String>> testInstanceRuns,
+            String entityId,
             String entityName,
             String runEntityId,
             String url,
             String domain,
             String project) {
-        
+        this.entityId = entityId;
         Map<String, Testsuite> testSetIdToTestsuite = getTestSets(testInstanceRuns);
         addTestcases(
                 testInstanceRuns,
@@ -94,33 +97,21 @@ public class JUnitParser {
         ret.setClassname(getTestSetName(entity, bvsName, runEntityId));
         ret.setName(getTestName(entity));
         ret.setTime(getTime(entity));
+        ret.setType(entity.get("test-subtype"));
         new TestcaseStatusUpdater().update(ret, entity, url, domain, project);
         
         return ret;
     }
-    
+
     private String getTestSetName(Map<String, String> entity, String bvsName, String runEntityId) {
-        
         String ret = String.format("%s.(Unnamed test set)", bvsName);
         String testSetName = entity.get("testset-name");
         if (!StringUtils.isNullOrEmpty(testSetName)) {
-            ret = String.format("%s (RunId:%s).%s", bvsName, runEntityId, testSetName);
+            ret = String.format("%s (id:%s).%s", bvsName, entityId, testSetName);
         }
-        
         return ret;
     }
-    
-    private String getTestInstanceRunId(Map<String, String> entity) {
-        
-        String ret = "No test instance run ID";
-        String runId = entity.get("run-id");
-        if (!StringUtils.isNullOrEmpty(runId)) {
-            ret = String.format("Test instance run ID: %s", runId);
-        }
-        
-        return ret;
-    }
-    
+
     private String getTestName(Map<String, String> entity) {
         
         String testName = entity.get("test-name");
@@ -128,7 +119,7 @@ public class JUnitParser {
             testName = "Unnamed test";
         }
         
-        return String.format("%s (%s)", testName, getTestInstanceRunId(entity));
+        return String.format("%s", testName);
     }
     
     private String getTime(Map<String, String> entity) {

--- a/src/main/java/com/hpe/application/automation/tools/sse/result/JUnitParser.java
+++ b/src/main/java/com/hpe/application/automation/tools/sse/result/JUnitParser.java
@@ -114,7 +114,7 @@ public class JUnitParser {
 
     private String getTestName(Map<String, String> entity) {
         
-        String testName = entity.get("test-name");
+        String testName = entity.get("test-config-name");
         if (StringUtils.isNullOrEmpty(testName)) {
             testName = "Unnamed test";
         }

--- a/src/main/java/com/hpe/application/automation/tools/sse/result/Publisher.java
+++ b/src/main/java/com/hpe/application/automation/tools/sse/result/Publisher.java
@@ -36,6 +36,7 @@ public abstract class Publisher extends Handler {
             ret =
                     new JUnitParser().toModel(
                             testInstanceRun,
+                            this.getEntityId(),
                             entityName,
                             _runId,
                             url,

--- a/src/main/resources/lib/octane/configure.js
+++ b/src/main/resources/lib/octane/configure.js
@@ -631,6 +631,10 @@ function octane_job_configuration(target, progress, proxy) {
             addApplyButton('Apply', pipeline, saveFunc, saveCallback);
         }
 
+        if(jobConfiguration.isUftJob) {
+            return;
+        }
+
         var CONFIRMATION = "There are unsaved changes, if you continue they will be discarded. Continue?";
 
         if (!jobConfiguration.hasOwnProperty("currentPipeline")) {

--- a/src/test/java/com/hpe/application/automation/tools/octane/tests/TestQueue.java
+++ b/src/test/java/com/hpe/application/automation/tools/octane/tests/TestQueue.java
@@ -26,7 +26,7 @@ import java.util.LinkedList;
 @SuppressWarnings("squid:S2925")
 public class TestQueue implements ResultQueue {
 
-	private LinkedList<QueueItem> queue = new LinkedList<QueueItem>();
+	private LinkedList<QueueItem> queue = new LinkedList<>();
 	private int discard;
 
 	@Override

--- a/src/test/java/com/hpe/application/automation/tools/octane/tests/TestResultQueueTest.java
+++ b/src/test/java/com/hpe/application/automation/tools/octane/tests/TestResultQueueTest.java
@@ -27,13 +27,13 @@ import java.io.IOException;
 @SuppressWarnings("squid:S2699")
 public class TestResultQueueTest {
 
-    private TestAbstractResultQueue queue;
+    private TestsResultQueue queue;
 
     @Before
     public void init() throws IOException {
         File file = File.createTempFile("TestResultQueueTest", "");
         file.delete();
-        queue = new TestAbstractResultQueue(file);
+        queue = new TestsResultQueue(file);
     }
 
     @Test

--- a/src/test/java/com/hpe/application/automation/tools/sse/sdk/TestRunManager.java
+++ b/src/test/java/com/hpe/application/automation/tools/sse/sdk/TestRunManager.java
@@ -290,10 +290,8 @@ public class TestRunManager extends TestCase {
         Testcase testcase = testsuites.getTestsuite().get(0).getTestcase().get(0);
         ret =
                 (testcase.getStatus().equals(JUnitTestCaseStatus.PASS))
-                        && (testcase.getName().equals("vapi1 (Test instance run ID: 7)"))
-                        && (testcase.getClassname().equals(String.format(
-                                "%s1 (RunId:1005).testset1",
-                                runType))) && (testcase.getTime().equals("0.0"));
+                        && (testcase.getName().equals("vapi1"))
+                        && (testcase.getClassname().equals(String.format("%s1 (id:1041).testset1", runType))) && (testcase.getTime().equals("0.0"));
         
         return ret;
     }
@@ -304,7 +302,7 @@ public class TestRunManager extends TestCase {
         Testcase testcase = testsuites.getTestsuite().get(0).getTestcase().get(0);
         ret =
                 (testcase.getStatus().equals("error"))
-                        && (testcase.getName().equals("Unnamed test (No test instance run ID)"))
+                        && (testcase.getName().equals("Unnamed test"))
                         && (testcase.getClassname().equals("PC Test ID: 5, Run ID: 42, Test Set ID: 1.(Unnamed test set)"))
                         && (testcase.getTime().equals("0.0"));
         


### PR DESCRIPTION
- log hidden exception

- promote mqm version to support base64 encoding in job name for multijob on secured envs
fixing PERFORMANCE_CENTER_RUNNER 
- Change the formet of test result
- defect #401115: Test results format - use test configuration for name
- Remove dependency of the plugin in BDI and make it send build logs to Octane instead of BDI (Jenkins plugin)

[JENKINS-45757](https://issues.jenkins-ci.org/browse/JENKINS-45757)
[JENKINS-45759](https://issues.jenkins-ci.org/browse/JENKINS-45759)
[JENKINS-46200](https://issues.jenkins-ci.org/browse/JENKINS-46200)