### PR TITLE
JENKINS-46900:Allow MC to accept relative path to APKs or to use envi…

### DIFF
--- a/src/main/java/com/hpe/application/automation/tools/run/UploadAppBuilder.java
+++ b/src/main/java/com/hpe/application/automation/tools/run/UploadAppBuilder.java
@@ -6,6 +6,7 @@ import com.hpe.application.automation.tools.model.ProxySettings;
 import com.hpe.application.automation.tools.model.UploadAppModel;
 import com.hpe.application.automation.tools.model.UploadAppPathModel;
 import com.hpe.application.automation.tools.settings.MCServerSettingsBuilder;
+import com.hpe.application.automation.tools.sse.common.StringUtils;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.Util;
@@ -15,10 +16,13 @@ import hudson.tasks.Builder;
 import net.minidev.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Created with IntelliJ IDEA.
@@ -55,14 +59,22 @@ public class UploadAppBuilder extends Builder {
         if(uploadAppModel != null){
             paths = uploadAppModel.getApplicationPaths();
         }
+        boolean allSuccess = true;
         if(mcServerSettingsModel == null){
             out.println("Failed to upload app to MC server. Cause: MC url didn't be configured." );
             return false;
         }else{
             mcServerUrl = mcServerSettingsModel.getProperties().getProperty("MobileHostAddress");
             out.println(String.format("There are %d apps to be uploaded.", paths.size()));
+            String workspace = new File(build.getWorkspace().toURI()).getCanonicalPath();
             for(int i=1; i<=paths.size(); i++){
                 String path = paths.get(i-1).getMcAppPath();
+                if(StringUtils.isNullOrEmpty(path)){
+                    out.println(String.format("ignore the empty app %d upload", i));
+                    continue;
+                }
+                //case insensitive replace of workspace to its real path
+                path = path.replaceAll("(?i)"+ Pattern.quote("${WORKSPACE}"), Matcher.quoteReplacement(workspace));
                 try{
                     out.println(String.format("starting to upload app %d %s", i, path));
                     if(uploadAppModel.getProxySettings() == null){
@@ -84,17 +96,25 @@ public class UploadAppBuilder extends Builder {
                         build.setResult(Result.FAILURE);
                         return false;
                     }
+                    if((Boolean)app.get("error")){
+                        out.println("Job failed because got error message during the application uploading. " + app.toJSONString());
+                        allSuccess = false;
+                        build.setResult(Result.FAILURE);
+                    }
                     out.println("uploaded app info: " + app.toJSONString());
                 } catch(FileNotFoundException fnf){
                     out.println(String.format("Failed to upload app to MC server. Cause: File: %s is not found.", path));
                     build.setResult(Result.FAILURE);
-                    return false;
+                    allSuccess = false;
+                    continue;
                 } catch (IOException ioe) {
                     Util.displayIOException(ioe, listener);
                     build.setResult(Result.FAILURE);
-                    return false;
+                    allSuccess = false;
+                    continue;
                 } catch (InterruptedException e) {
                     build.setResult(Result.ABORTED);
+                    return false;
                 } catch (Exception e){
                     if(uploadAppModel.isUseProxy()){
                         out.println(String.format("Failed to upload app, Cause MC connection info is incorrect. url:%s, username:%s, Proxy url:%s",
@@ -111,7 +131,7 @@ public class UploadAppBuilder extends Builder {
                 }
             }
         }
-        return true;
+        return allSuccess;
     }
 
     public MCServerSettingsModel getMCServerSettingsModel() {


### PR DESCRIPTION
…ronment variables in qualifying path to APK
https://issues.jenkins-ci.org/browse/JENKINS-46900

When using the "Upload app to Mobile Center" as a build step, when specifying the application path to the APK, a relative path to the workspace should be allowed to be given instead of the fully qualified path. This ensures that we don't need to know where the workspace is actually located during the build. Also, the application path should allow for use of environment variables in order to dictate the path. i.e. ${WORKSPACE}/my-app.apk


Please Make sure these boxes are checked before submitting your pull request - Thanks ahead!

- [x] Proper pull request title - concise and clear for others.
- [x] Proper pull request short description - clear and concise (as it should appear in the Jira ticket) for other developers and users.
- [x] Proper Jira ticket - Number, Link in pull request description.
- [x] The PR can is merged on your machine without any conflicts.
- [x] The PR can is built on your machine without any (new) warnings.
- [x] The PR passed sanity tests by you / QA / DevTest / Good Samaritain.
- [x] Add unit tests with new features.
- [x] If you added any dependency to the POM - Please update @YafimK
